### PR TITLE
Show "Latest prerelease" above the separator when it's the newest version

### DIFF
--- a/src/PackageManagement.UI/PackageDetailControlModel.cs
+++ b/src/PackageManagement.UI/PackageDetailControlModel.cs
@@ -104,6 +104,7 @@ namespace NuGet.PackageManagement.UI
                 StringComparer.OrdinalIgnoreCase.Equals(p.Id, Id)).SingleOrDefault();
 
             var allVersions = _allPackages.OrderByDescending(v => v);
+            var latestPrerelease = allVersions.FirstOrDefault(v => v.IsPrerelease);
             var latestStableVersion = allVersions.FirstOrDefault(v => !v.IsPrerelease);
 
             if (SelectedAction == Resources.Action_Uninstall)
@@ -112,11 +113,19 @@ namespace NuGet.PackageManagement.UI
             }
             else if (SelectedAction == Resources.Action_Install)
             {
+                if (latestPrerelease != null && (latestStableVersion == null || latestPrerelease > latestStableVersion))
+                {
+                    _versions.Add(new VersionForDisplay(latestPrerelease, Resources.Version_LatestPrerelease));
+                }
+
                 if (latestStableVersion != null)
                 {
                     _versions.Add(new VersionForDisplay(latestStableVersion, Resources.Version_LatestStable));
+                }
 
-                    // add a separator
+                // add a separator
+                if (_versions.Count > 0)
+                {
                     _versions.Add(null);
                 }
 

--- a/src/PackageManagement.UI/PackageSolutionDetailControlModel.cs
+++ b/src/PackageManagement.UI/PackageSolutionDetailControlModel.cs
@@ -85,11 +85,17 @@ namespace NuGet.PackageManagement.UI
             {
                 _versions = new List<VersionForDisplay>();
                 var allVersions = _allPackages.OrderByDescending(v => v);
+                var latestPrerelease = allVersions.FirstOrDefault(v => v.IsPrerelease);
                 var latestStableVersion = allVersions.FirstOrDefault(v => !v.IsPrerelease);
+
+                if (latestPrerelease != null && (latestStableVersion == null || latestPrerelease > latestStableVersion))
+                {
+                    _versions.Add(new VersionForDisplay(latestPrerelease, Resources.Version_LatestPrerelease));
+                }
+
                 if (latestStableVersion != null)
                 {
-                    _versions.Add(new VersionForDisplay(latestStableVersion,
-                        Resources.Version_LatestStable));
+                    _versions.Add(new VersionForDisplay(latestStableVersion, Resources.Version_LatestStable));
                 }
 
                 // add a separator

--- a/src/PackageManagement.UI/Resources.resx
+++ b/src/PackageManagement.UI/Resources.resx
@@ -423,4 +423,7 @@ Packages installed into Website projects will not be restored during build. Cons
   <data name="Action_Update" xml:space="preserve">
     <value>Update</value>
   </data>
+  <data name="Version_LatestPrerelease" xml:space="preserve">
+    <value>Latest prerelease</value>
+  </data>
 </root>

--- a/src/PackageManagement.UI/Resources1.Designer.cs
+++ b/src/PackageManagement.UI/Resources1.Designer.cs
@@ -918,6 +918,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Latest prerelease.
+        /// </summary>
+        public static string Version_LatestPrerelease {
+            get {
+                return ResourceManager.GetString("Version_LatestPrerelease", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Latest stable.
         /// </summary>
         public static string Version_LatestStable {


### PR DESCRIPTION
Fixes NuGet/Home#76.