### PR TITLE
Format to tabs with two spaces and general code cleanup

### DIFF
--- a/src/PackageManagement.UI/Xamls/ActionsAndVersions.xaml
+++ b/src/PackageManagement.UI/Xamls/ActionsAndVersions.xaml
@@ -1,65 +1,78 @@
-﻿<UserControl x:Class="NuGet.PackageManagement.UI.ActionsAndVersions"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:Tools="clr-namespace:NuGet.PackageManagement.UI"
-             xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"             
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             Background="{DynamicResource {x:Static resx:Brushes.HeaderBackground}}"
-             Foreground="{DynamicResource {x:Static resx:Brushes.UIText}}"
-             mc:Ignorable="d"
-             d:DesignHeight="300" d:DesignWidth="350">
-    <UserControl.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="Resources.xaml" />
-            </ResourceDictionary.MergedDictionaries>
-            <Tools:VersionToVersionForDisplayConverter x:Key="VersionToVersionForDisplayConverter" />
+﻿<UserControl
+  x:Class="NuGet.PackageManagement.UI.ActionsAndVersions"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:Tools="clr-namespace:NuGet.PackageManagement.UI"
+  xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  Background="{DynamicResource {x:Static resx:Brushes.HeaderBackground}}"
+  Foreground="{DynamicResource {x:Static resx:Brushes.UIText}}"
+  mc:Ignorable="d"
+  d:DesignHeight="300"
+  d:DesignWidth="350">
+  <UserControl.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary
+          Source="Resources.xaml" />
+      </ResourceDictionary.MergedDictionaries>
+      <Tools:VersionToVersionForDisplayConverter
+        x:Key="VersionToVersionForDisplayConverter" />
 
-            <ControlTemplate x:Key="SeparatorControlTemplate">
-                <Separator HorizontalAlignment="Stretch" IsEnabled="False" />
-            </ControlTemplate>
-        </ResourceDictionary>
-    </UserControl.Resources>
-    <Grid>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="12" />
-            <ColumnDefinition Width="Auto" />
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="auto" />
-            <RowDefinition Height="8" />
-            <RowDefinition Height="auto" />
-        </Grid.RowDefinitions>
-        <TextBlock
-            Grid.Row="0"
-            Grid.Column="0"
-            FontWeight="Bold"
-            Text="{x:Static resx:Resources.Label_Action}" />
-        <ComboBox
-            x:Name="_actions"
-            Grid.Row="3"
-            Grid.Column="0"            
-            MinWidth="150"
-            MinHeight="22"
-            AutomationProperties.Name="{x:Static resx:Resources.Label_Action}"
-            ItemsSource="{Binding Path=Actions}"
-            SelectedItem="{Binding Path=SelectedAction}" />
+      <ControlTemplate
+        x:Key="SeparatorControlTemplate">
+        <Separator
+          HorizontalAlignment="Stretch"
+          IsEnabled="False" />
+      </ControlTemplate>
+    </ResourceDictionary>
+  </UserControl.Resources>
+  <Grid>
+    <Grid.ColumnDefinitions>
+      <ColumnDefinition
+        Width="Auto" />
+      <ColumnDefinition
+        Width="12" />
+      <ColumnDefinition
+        Width="Auto" />
+    </Grid.ColumnDefinitions>
+    <Grid.RowDefinitions>
+      <RowDefinition
+        Height="auto" />
+      <RowDefinition
+        Height="8" />
+      <RowDefinition
+        Height="auto" />
+    </Grid.RowDefinitions>
+    <TextBlock
+      Grid.Row="0"
+      Grid.Column="0"
+      FontWeight="Bold"
+      Text="{x:Static resx:Resources.Label_Action}" />
+    <ComboBox
+      x:Name="_actions"
+      Grid.Row="3"
+      Grid.Column="0"
+      MinWidth="150"
+      MinHeight="22"
+      AutomationProperties.Name="{x:Static resx:Resources.Label_Action}"
+      ItemsSource="{Binding Path=Actions}"
+      SelectedItem="{Binding Path=SelectedAction}" />
 
-        <TextBlock
-            Grid.Row="0"
-            Grid.Column="2"
-            FontWeight="Bold"
-            Text="{x:Static resx:Resources.Label_Version}" />
-        <ComboBox
-            x:Name="_versions"
-            Grid.Row="3"
-            Grid.Column="2"
-            MinWidth="150"
-            MinHeight="22"       
-            AutomationProperties.Name="{x:Static resx:Resources.Label_Version}"
-            ItemsSource="{Binding Path=Versions}"
-            SelectedItem="{Binding Path=SelectedVersion}" />
-    </Grid>
+    <TextBlock
+      Grid.Row="0"
+      Grid.Column="2"
+      FontWeight="Bold"
+      Text="{x:Static resx:Resources.Label_Version}" />
+    <ComboBox
+      x:Name="_versions"
+      Grid.Row="3"
+      Grid.Column="2"
+      MinWidth="150"
+      MinHeight="22"
+      AutomationProperties.Name="{x:Static resx:Resources.Label_Version}"
+      ItemsSource="{Binding Path=Versions}"
+      SelectedItem="{Binding Path=SelectedVersion}" />
+  </Grid>
 </UserControl>

--- a/src/PackageManagement.UI/Xamls/DetailControl.xaml
+++ b/src/PackageManagement.UI/Xamls/DetailControl.xaml
@@ -1,97 +1,117 @@
-﻿<UserControl x:Class="NuGet.PackageManagement.UI.DetailControl"
-             xmlns:Tools="clr-namespace:NuGet.PackageManagement.UI"
-             xmlns:k ="clr-namespace:NuGet.PackageManagement.UI"
-             xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             Background="{Binding UIBrushes.DetailPaneBackground }"
-             x:Name="_self"
-             mc:Ignorable="d"
-             d:DesignHeight="600" d:DesignWidth="400">
-    <UserControl.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="Resources.xaml" />
-            </ResourceDictionary.MergedDictionaries>
-        </ResourceDictionary>
-    </UserControl.Resources>
-    <UserControl.CommandBindings>
-        <CommandBinding
-            Command="{x:Static Tools:PackageManagerControlCommands.OpenExternalLink}"
-            Executed="ExecuteOpenLicenseLink" />
-    </UserControl.CommandBindings>
-    <ScrollViewer x:Name="_root" HorizontalScrollBarVisibility="Disabled">
-        <Grid Margin="24,0,7,0">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
+﻿<UserControl
+  x:Class="NuGet.PackageManagement.UI.DetailControl"
+  xmlns:Tools="clr-namespace:NuGet.PackageManagement.UI"
+  xmlns:k="clr-namespace:NuGet.PackageManagement.UI"
+  xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  Background="{Binding UIBrushes.DetailPaneBackground }"
+  x:Name="_self"
+  mc:Ignorable="d"
+  d:DesignHeight="600"
+  d:DesignWidth="400">
+  <UserControl.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary
+          Source="Resources.xaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </UserControl.Resources>
+  <UserControl.CommandBindings>
+    <CommandBinding
+      Command="{x:Static Tools:PackageManagerControlCommands.OpenExternalLink}"
+      Executed="ExecuteOpenLicenseLink" />
+  </UserControl.CommandBindings>
+  <ScrollViewer
+    x:Name="_root"
+    HorizontalScrollBarVisibility="Disabled">
+    <Grid
+      Margin="24,0,7,0">
+      <Grid.RowDefinitions>
+        <RowDefinition
+          Height="Auto" />
+        <RowDefinition
+          Height="Auto" />
+        <RowDefinition
+          Height="Auto" />
+        <RowDefinition
+          Height="Auto" />
+        <RowDefinition
+          Height="Auto" />
+        <RowDefinition
+          Height="Auto" />
+      </Grid.RowDefinitions>
 
-            <!-- Icon and Id -->
-            <StackPanel Grid.Row="0"
-                        Orientation="Horizontal"
-                        MinHeight="32"
-                        Margin="0,8">
-                <Image
-                    Source="{Binding Path=IconUrl,TargetNullValue={StaticResource BitmapImage_DefaultIcon}}"
-                    Margin="0,0,8,0"
-                    Height="32"
-                    Width="32"
-                    Style="{StaticResource PackageIconImageStyle}"
-                    RenderOptions.BitmapScalingMode="HighQuality" />
-                <TextBlock
-                    Text="{Binding Path=Id}"
-                    FontSize="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font155PercentSizeConverter}}" />
-            </StackPanel>
+      <!-- Icon and Id -->
+      <StackPanel
+        Grid.Row="0"
+        Orientation="Horizontal"
+        MinHeight="32"
+        Margin="0,8">
+        <Image
+          Source="{Binding Path=IconUrl,TargetNullValue={StaticResource BitmapImage_DefaultIcon}}"
+          Margin="0,0,8,0"
+          Height="32"
+          Width="32"
+          Style="{StaticResource PackageIconImageStyle}"
+          RenderOptions.BitmapScalingMode="HighQuality" />
+        <TextBlock
+          Text="{Binding Path=Id}"
+          FontSize="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font155PercentSizeConverter}}" />
+      </StackPanel>
 
-            <!-- Action and Versions -->
-            <Tools:ActionsAndVersions Grid.Row="1"  Margin="0,8" />
+      <!-- Action and Versions -->
+      <Tools:ActionsAndVersions
+        Grid.Row="1"
+        Margin="0,8" />
 
-            <!-- Project list -->
-            <Tools:ProjectList
-                x:Name="_projectList"
-                Grid.Row="2"
-                Margin="0,12,0,8"
-                Visibility="{Binding Path=IsSolution,Converter={StaticResource BooleanToVisibilityConverter}}" />
-            
-            <!-- Installed Version  -->
-            <StackPanel Grid.Row="2"
-                        Margin="0,12,0,8"
-                        Visibility="{Binding Path=InstalledVersion,Converter={StaticResource NullToVisibilityConverter}}">
-                <TextBlock Text="{Binding Path=InstalledVersion}" />
-            </StackPanel>
+      <!-- Project list -->
+      <Tools:ProjectList
+        x:Name="_projectList"
+        Grid.Row="2"
+        Margin="0,12,0,8"
+        Visibility="{Binding Path=IsSolution,Converter={StaticResource BooleanToVisibilityConverter}}" />
 
-            <Border Grid.Row="3"
-                    BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
-                    BorderThickness="0,0,0,1">
-                <Button
-                    Margin="0,8,0,16"
-                    MinWidth="100"
-                    MinHeight="24"
-                    HorizontalAlignment="Left"
-                    IsEnabled="{Binding Path=ActionEnabled}"
-                    Content="{Binding Path=SelectedAction}"
-                    Click="ActionButtonClicked" />
-            </Border>
+      <!-- Installed Version  -->
+      <StackPanel
+        Grid.Row="2"
+        Margin="0,12,0,8"
+        Visibility="{Binding Path=InstalledVersion,Converter={StaticResource NullToVisibilityConverter}}">
+        <TextBlock
+          Text="{Binding Path=InstalledVersion}" />
+      </StackPanel>
 
-            <!-- options -->
-            <Border Grid.Row="4"
-                    BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
-                    BorderThickness="0,0,0,1">
-                <Tools:OptionsControl
-                    Margin="0,12,0,16"
-                    DataContext="{Binding}" />
-            </Border>
+      <Border
+        Grid.Row="3"
+        BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+        BorderThickness="0,0,0,1">
+        <Button
+          Margin="0,8,0,16"
+          MinWidth="100"
+          MinHeight="24"
+          HorizontalAlignment="Left"
+          IsEnabled="{Binding Path=ActionEnabled}"
+          Content="{Binding Path=SelectedAction}"
+          Click="ActionButtonClicked" />
+      </Border>
 
-            <Tools:PackageMetadataControl
-                Grid.Row="5" Margin="0,12,0,0"
-                DataContext="{Binding PackageMetadata}" />
-        </Grid>
-    </ScrollViewer>
+      <!-- options -->
+      <Border
+        Grid.Row="4"
+        BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+        BorderThickness="0,0,0,1">
+        <Tools:OptionsControl
+          Margin="0,12,0,16"
+          DataContext="{Binding}" />
+      </Border>
+
+      <Tools:PackageMetadataControl
+        Grid.Row="5"
+        Margin="0,12,0,0"
+        DataContext="{Binding PackageMetadata}" />
+    </Grid>
+  </ScrollViewer>
 </UserControl>

--- a/src/PackageManagement.UI/Xamls/FileConflictDialog.xaml
+++ b/src/PackageManagement.UI/Xamls/FileConflictDialog.xaml
@@ -1,45 +1,76 @@
 ﻿<ui:VsDialogWindow
-    x:Class="NuGet.PackageManagement.UI.FileConflictDialog"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
-    xmlns:ui="clr-namespace:NuGet.PackageManagement.UI"
-    Background="{DynamicResource {x:Static resx:Brushes.HeaderBackground}}"
-    Foreground="{DynamicResource {x:Static resx:Brushes.UIText}}"
-    Title="{x:Static resx:Resources.WindowTitle_FileConflict}"
-    ShowInTaskbar="False"
-    WindowStartupLocation="CenterOwner"
-    MinHeight="180"
-    MinWidth="500"
-    MaxWidth="900"
-    Width="500"
-    Height="180"
-    mc:Ignorable="d"
-    d:DesignHeight="180" d:DesignWidth="500">    
-    <Window.Resources>
-        <Style TargetType="{x:Type Button}">
-            <Setter Property="Margin" Value="6,6,6,2" />
-            <Setter Property="Padding" Value="10,3,10,3" />
-            <Setter Property="MinWidth" Value="75" />
-        </Style>
-    </Window.Resources>
+  x:Class="NuGet.PackageManagement.UI.FileConflictDialog"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
+  xmlns:ui="clr-namespace:NuGet.PackageManagement.UI"
+  Background="{DynamicResource {x:Static resx:Brushes.HeaderBackground}}"
+  Foreground="{DynamicResource {x:Static resx:Brushes.UIText}}"
+  Title="{x:Static resx:Resources.WindowTitle_FileConflict}"
+  ShowInTaskbar="False"
+  WindowStartupLocation="CenterOwner"
+  MinHeight="180"
+  MinWidth="500"
+  MaxWidth="900"
+  Width="500"
+  Height="180"
+  mc:Ignorable="d"
+  d:DesignHeight="180"
+  d:DesignWidth="500">
+  <Window.Resources>
+    <Style
+      TargetType="{x:Type Button}">
+      <Setter
+        Property="Margin"
+        Value="6,6,6,2" />
+      <Setter
+        Property="Padding"
+        Value="10,3,10,3" />
+      <Setter
+        Property="MinWidth"
+        Value="75" />
+    </Style>
+  </Window.Resources>
 
-    <DockPanel Margin="10">
-        <StackPanel DockPanel.Dock="Bottom" Margin="0,0,0,3" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Content="{x:Static resx:Resources.Button_Yes}" Tag="Overwrite" AutomationProperties.AutomationId="YesButton" Click="Button_Click" />
-            <Button Content="{x:Static resx:Resources.Button_YesToAll}" Tag="OverwriteAll" AutomationProperties.AutomationId="YesToAllButton" Click="Button_Click" />
-            <Button x:Name="NoButton" Content="{x:Static resx:Resources.Button_No}" Tag="Ignore" AutomationProperties.AutomationId="NoButton" IsDefault="True" Click="Button_Click" />
-            <Button Content="{x:Static resx:Resources.Button_NoToAll}" Tag="IgnoreAll" AutomationProperties.AutomationId="NoToAllButton" Click="Button_Click" />
-        </StackPanel>
+  <DockPanel
+    Margin="10">
+    <StackPanel
+      DockPanel.Dock="Bottom"
+      Margin="0,0,0,3"
+      Orientation="Horizontal"
+      HorizontalAlignment="Right">
+      <Button
+        Content="{x:Static resx:Resources.Button_Yes}"
+        Tag="Overwrite"
+        AutomationProperties.AutomationId="YesButton"
+        Click="Button_Click" />
+      <Button
+        Content="{x:Static resx:Resources.Button_YesToAll}"
+        Tag="OverwriteAll"
+        AutomationProperties.AutomationId="YesToAllButton"
+        Click="Button_Click" />
+      <Button
+        x:Name="NoButton"
+        Content="{x:Static resx:Resources.Button_No}"
+        Tag="Ignore"
+        AutomationProperties.AutomationId="NoButton"
+        IsDefault="True"
+        Click="Button_Click" />
+      <Button
+        Content="{x:Static resx:Resources.Button_NoToAll}"
+        Tag="IgnoreAll"
+        AutomationProperties.AutomationId="NoToAllButton"
+        Click="Button_Click" />
+    </StackPanel>
 
-        <TextBlock
-            x:Name="QuestionText"
-            x:FieldModifier="private"
-            DockPanel.Dock="Top"
-            Margin="0,3,0,3"
-            TextWrapping="Wrap"
-            VerticalAlignment="Top" />
-    </DockPanel>
+    <TextBlock
+      x:Name="QuestionText"
+      x:FieldModifier="private"
+      DockPanel.Dock="Top"
+      Margin="0,3,0,3"
+      TextWrapping="Wrap"
+      VerticalAlignment="Top" />
+  </DockPanel>
 </ui:VsDialogWindow>

--- a/src/PackageManagement.UI/Xamls/InfiniteScrollList.xaml
+++ b/src/PackageManagement.UI/Xamls/InfiniteScrollList.xaml
@@ -1,149 +1,249 @@
-﻿<UserControl x:Class="NuGet.PackageManagement.UI.InfiniteScrollList"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
-             xmlns:self="clr-namespace:NuGet.PackageManagement.UI"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             mc:Ignorable="d"
-             d:DesignHeight="300" d:DesignWidth="300">
-    <UserControl.Resources>
-        <self:InfiniteScrollListItemStyleSelector x:Key="itemStyleSelector" />
-        <DataTemplate DataType="{x:Type self:LoadingStatusIndicator}">
-            <Grid Margin="0,8">
-                <TextBlock Name="_noItemsFound"
-                           FontStyle="Italic"
-                           HorizontalAlignment="Center"
-                           Text="{x:Static resx:Resources.Text_NoItemsFound}"
-                           Visibility="Collapsed" />
+﻿<UserControl
+  x:Class="NuGet.PackageManagement.UI.InfiniteScrollList"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
+  xmlns:self="clr-namespace:NuGet.PackageManagement.UI"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  mc:Ignorable="d"
+  d:DesignHeight="300"
+  d:DesignWidth="300">
+  <UserControl.Resources>
+    <self:InfiniteScrollListItemStyleSelector
+      x:Key="itemStyleSelector" />
+    <DataTemplate
+      DataType="{x:Type self:LoadingStatusIndicator}">
+      <Grid
+        Margin="0,8">
+        <TextBlock
+          Name="_noItemsFound"
+          FontStyle="Italic"
+          HorizontalAlignment="Center"
+          Text="{x:Static resx:Resources.Text_NoItemsFound}"
+          Visibility="Collapsed" />
 
-                <TextBlock Name="_ready"
-                           HorizontalAlignment="Center"
-                           Text="{x:Static resx:Resources.Text_Ready}"
-                           Visibility="Collapsed" />
+        <TextBlock
+          Name="_ready"
+          HorizontalAlignment="Center"
+          Text="{x:Static resx:Resources.Text_Ready}"
+          Visibility="Collapsed" />
 
-                <StackPanel Orientation="Vertical"
-                            Name="_progressBar"
-                            Visibility="Collapsed">
-                    <ProgressBar
-                        Margin="24,0"
-                        Height="15" IsIndeterminate="True" />
-                    <TextBlock Margin="0,8"
-                               Text="{Binding Path=LoadingMessage}"
-                               HorizontalAlignment="Center" />
-                </StackPanel>
+        <StackPanel
+          Orientation="Vertical"
+          Name="_progressBar"
+          Visibility="Collapsed">
+          <ProgressBar
+            Margin="24,0"
+            Height="15"
+            IsIndeterminate="True" />
+          <TextBlock
+            Margin="0,8"
+            Text="{Binding Path=LoadingMessage}"
+            HorizontalAlignment="Center" />
+        </StackPanel>
 
 
-                <StackPanel Orientation="Vertical" Name="_errorOccurred"
-                            Visibility="Collapsed">
-                    <Button Click="RetryButtonClicked"
-                            Content="{x:Static resx:Resources.Button_Retry}"
-                            MinWidth="150" />
-                    <Expander Margin="0,8,0,0"
-                              Header="{x:Static resx:Resources.Text_ErrorDetails}"
-                              >
-                        <TextBox 
-                             IsReadOnly="True"
-                             TextWrapping="Wrap"
-                             Text="{Binding ErrorMessage}" />
-                    </Expander>
-                </StackPanel>
-            </Grid>
-            <DataTemplate.Triggers>
-                <DataTrigger Binding="{Binding Path=Status}" Value="Loading">
-                    <Setter TargetName="_progressBar"
-                            Property="Visibility"
-                            Value="Visible" />
-                </DataTrigger>
-                <DataTrigger Binding="{Binding Path=Status}" Value="Ready">
-                    <Setter TargetName="_ready"
-                            Property="Visibility"
-                            Value="Visible" />
-                </DataTrigger>
-                <DataTrigger Binding="{Binding Path=Status}" Value="NoItemsFound">
-                    <Setter TargetName="_noItemsFound"
-                            Property="Visibility"
-                            Value="Visible" />
-                </DataTrigger>
-                <DataTrigger Binding="{Binding Path=Status}" Value="ErrorOccured">
-                    <Setter TargetName="_errorOccurred"
-                            Property="Visibility"
-                            Value="Visible" />
-                </DataTrigger>
-            </DataTemplate.Triggers>
-        </DataTemplate>
+        <StackPanel
+          Orientation="Vertical"
+          Name="_errorOccurred"
+          Visibility="Collapsed">
+          <Button
+            Click="RetryButtonClicked"
+            Content="{x:Static resx:Resources.Button_Retry}"
+            MinWidth="150" />
+          <Expander
+            Margin="0,8,0,0"
+            Header="{x:Static resx:Resources.Text_ErrorDetails}">
+            <TextBox
+              IsReadOnly="True"
+              TextWrapping="Wrap"
+              Text="{Binding ErrorMessage}" />
+          </Expander>
+        </StackPanel>
+      </Grid>
+      <DataTemplate.Triggers>
+        <DataTrigger
+          Binding="{Binding Path=Status}"
+          Value="Loading">
+          <Setter
+            TargetName="_progressBar"
+            Property="Visibility"
+            Value="Visible" />
+        </DataTrigger>
+        <DataTrigger
+          Binding="{Binding Path=Status}"
+          Value="Ready">
+          <Setter
+            TargetName="_ready"
+            Property="Visibility"
+            Value="Visible" />
+        </DataTrigger>
+        <DataTrigger
+          Binding="{Binding Path=Status}"
+          Value="NoItemsFound">
+          <Setter
+            TargetName="_noItemsFound"
+            Property="Visibility"
+            Value="Visible" />
+        </DataTrigger>
+        <DataTrigger
+          Binding="{Binding Path=Status}"
+          Value="ErrorOccured">
+          <Setter
+            TargetName="_errorOccurred"
+            Property="Visibility"
+            Value="Visible" />
+        </DataTrigger>
+      </DataTemplate.Triggers>
+    </DataTemplate>
 
-        <!-- Template used by ListBoxItem that represents a package. -->
-        <ControlTemplate x:Key="ListBoxItemTemplate" TargetType="{x:Type ListBoxItem}">
-            <Border x:Name="Bd" BorderThickness="0" Background="{TemplateBinding Background}" Padding="0" SnapsToDevicePixels="true">
-                <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
-            </Border>
-            <ControlTemplate.Triggers>
-                <!-- set the background for IsEnabled == false -->
-                <Trigger Property="IsEnabled" Value="false" >
-                    <Setter Property="Background" TargetName="Bd" Value="{DynamicResource {x:Static resx:Brushes.ListPaneBackground}}" />
-                </Trigger>
-                
-                <MultiTrigger>
-                    <MultiTrigger.Conditions>
-                        <Condition Property="IsMouseOver" Value="True" />
-                    </MultiTrigger.Conditions>
-                    <Setter Property="Background" TargetName="Bd" 
-                                            Value="{DynamicResource {x:Static resx:Brushes.ContentMouseOverBrushKey}}" />
-                </MultiTrigger>
-                <MultiTrigger>
-                    <MultiTrigger.Conditions>
-                        <Condition Property="Selector.IsSelectionActive" Value="False" />
-                        <Condition Property="IsSelected" Value="True" />
-                    </MultiTrigger.Conditions>
-                    <Setter Property="Background" TargetName="Bd" Value="{DynamicResource {x:Static resx:Brushes.ContentInactiveSelectedBrushKey}}" />
-                </MultiTrigger>
-                <MultiTrigger>
-                    <MultiTrigger.Conditions>
-                        <Condition Property="Selector.IsSelectionActive" Value="True" />
-                        <Condition Property="IsSelected" Value="True" />
-                    </MultiTrigger.Conditions>
-                    <Setter Property="Background" TargetName="Bd" Value="{DynamicResource {x:Static resx:Brushes.ContentSelectedBrushKey}}" />
-                    <Setter Property="TextBlock.Foreground" TargetName="Bd" Value="{DynamicResource {x:Static resx:Brushes.ContentSelectedTextBrushKey}}" />
-                </MultiTrigger>
-            </ControlTemplate.Triggers>
-        </ControlTemplate>
+    <!-- Template used by ListBoxItem that represents a package. -->
+    <ControlTemplate
+      x:Key="ListBoxItemTemplate"
+      TargetType="{x:Type ListBoxItem}">
+      <Border
+        x:Name="Bd"
+        BorderThickness="0"
+        Background="{TemplateBinding Background}"
+        Padding="0"
+        SnapsToDevicePixels="true">
+        <ContentPresenter
+          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+          VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+      </Border>
+      <ControlTemplate.Triggers>
+        <!-- set the background for IsEnabled == false -->
+        <Trigger
+          Property="IsEnabled"
+          Value="false">
+          <Setter
+            Property="Background"
+            TargetName="Bd"
+            Value="{DynamicResource {x:Static resx:Brushes.ListPaneBackground}}" />
+        </Trigger>
 
-        <!-- Template used by the LoadingIndicator. We use it to disable the background change when mouse hovers over it. -->
-        <ControlTemplate x:Key="LoadingIndicatorListBoxItemTemplate" TargetType="{x:Type ListBoxItem}">
-            <Border x:Name="Bd" BorderThickness="0" Background="{DynamicResource {x:Static resx:Brushes.ListPaneBackground}}" Padding="0" SnapsToDevicePixels="true">
-                <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
-            </Border>
-        </ControlTemplate>
+        <MultiTrigger>
+          <MultiTrigger.Conditions>
+            <Condition
+              Property="IsMouseOver"
+              Value="True" />
+          </MultiTrigger.Conditions>
+          <Setter
+            Property="Background"
+            TargetName="Bd"
+            Value="{DynamicResource {x:Static resx:Brushes.ContentMouseOverBrushKey}}" />
+        </MultiTrigger>
+        <MultiTrigger>
+          <MultiTrigger.Conditions>
+            <Condition
+              Property="Selector.IsSelectionActive"
+              Value="False" />
+            <Condition
+              Property="IsSelected"
+              Value="True" />
+          </MultiTrigger.Conditions>
+          <Setter
+            Property="Background"
+            TargetName="Bd"
+            Value="{DynamicResource {x:Static resx:Brushes.ContentInactiveSelectedBrushKey}}" />
+        </MultiTrigger>
+        <MultiTrigger>
+          <MultiTrigger.Conditions>
+            <Condition
+              Property="Selector.IsSelectionActive"
+              Value="True" />
+            <Condition
+              Property="IsSelected"
+              Value="True" />
+          </MultiTrigger.Conditions>
+          <Setter
+            Property="Background"
+            TargetName="Bd"
+            Value="{DynamicResource {x:Static resx:Brushes.ContentSelectedBrushKey}}" />
+          <Setter
+            Property="TextBlock.Foreground"
+            TargetName="Bd"
+            Value="{DynamicResource {x:Static resx:Brushes.ContentSelectedTextBrushKey}}" />
+        </MultiTrigger>
+      </ControlTemplate.Triggers>
+    </ControlTemplate>
 
-        <Style x:Key="FocusVisual">
-            <Setter Property="Control.Template">
-                <Setter.Value>
-                    <ControlTemplate>
-                        <Rectangle Margin="2" SnapsToDevicePixels="true" Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" StrokeThickness="1" StrokeDashArray="1 2" />
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
+    <!-- Template used by the LoadingIndicator. We use it to disable the background change when mouse hovers over it. -->
+    <ControlTemplate
+      x:Key="LoadingIndicatorListBoxItemTemplate"
+      TargetType="{x:Type ListBoxItem}">
+      <Border
+        x:Name="Bd"
+        BorderThickness="0"
+        Background="{DynamicResource {x:Static resx:Brushes.ListPaneBackground}}"
+        Padding="0"
+        SnapsToDevicePixels="true">
+        <ContentPresenter
+          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+          VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+      </Border>
+    </ControlTemplate>
 
-        <!-- the base style of the ListBoxItem. -->
-        <Style x:Key="listBoxItemStyle" TargetType="{x:Type ListBoxItem}">
-            <Setter Property="Padding" Value="0" />
-            <Setter Property="SnapsToDevicePixels" Value="True" />
-            <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
-            <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
-            <Setter Property="Background" Value="Transparent"/>
-            <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}" />
-        </Style>
+    <Style
+      x:Key="FocusVisual">
+      <Setter
+        Property="Control.Template">
+        <Setter.Value>
+          <ControlTemplate>
+            <Rectangle
+              Margin="2"
+              SnapsToDevicePixels="true"
+              Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
+              StrokeThickness="1"
+              StrokeDashArray="1 2" />
+          </ControlTemplate>
+        </Setter.Value>
+      </Setter>
+    </Style>
 
-        <!-- the style of the ListBoxItem when the item is the loading status indicator. -->
-        <Style x:Key="loadingStatusIndicatorStyle" TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource listBoxItemStyle}">
-            <Setter Property="Template" Value="{StaticResource LoadingIndicatorListBoxItemTemplate}" />
-        </Style>
+    <!-- the base style of the ListBoxItem. -->
+    <Style
+      x:Key="listBoxItemStyle"
+      TargetType="{x:Type ListBoxItem}">
+      <Setter
+        Property="Padding"
+        Value="0" />
+      <Setter
+        Property="SnapsToDevicePixels"
+        Value="True" />
+      <Setter
+        Property="HorizontalContentAlignment"
+        Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+      <Setter
+        Property="VerticalContentAlignment"
+        Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+      <Setter
+        Property="Background"
+        Value="Transparent" />
+      <Setter
+        Property="FocusVisualStyle"
+        Value="{StaticResource FocusVisual}" />
+    </Style>
 
-        <!-- the style of the ListBoxItem when the item is a package. -->
-        <Style x:Key="packageItemStyle" TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource listBoxItemStyle}">
-            <!-- 
+    <!-- the style of the ListBoxItem when the item is the loading status indicator. -->
+    <Style
+      x:Key="loadingStatusIndicatorStyle"
+      TargetType="{x:Type ListBoxItem}"
+      BasedOn="{StaticResource listBoxItemStyle}">
+      <Setter
+        Property="Template"
+        Value="{StaticResource LoadingIndicatorListBoxItemTemplate}" />
+    </Style>
+
+    <!-- the style of the ListBoxItem when the item is a package. -->
+    <Style
+      x:Key="packageItemStyle"
+      TargetType="{x:Type ListBoxItem}"
+      BasedOn="{StaticResource listBoxItemStyle}">
+      <!-- 
             Note that we cannot set the template property in xaml list this:
             
                <Setter Property="Template" Value="{StaticResource ListBoxItemTemplate}" /> 
@@ -152,27 +252,38 @@
             available when this is used in the standalone mode, i.e. outside of VisualStudio. So the setter is 
             added by code when Standalone == false.
             -->
-        </Style>
-    </UserControl.Resources>
-    <ListBox x:Name="_list"
-             Background="{DynamicResource {x:Static resx:Brushes.ListPaneBackground}}"
-             Foreground="{DynamicResource {x:Static resx:Brushes.UIText}}"
-             ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-             ScrollViewer.VerticalScrollBarVisibility="Visible"
-             ItemContainerStyleSelector="{DynamicResource itemStyleSelector}"
-             BorderThickness="0,0,0,1"
-             HorizontalContentAlignment="Stretch"
-             SelectionChanged="List_SelectionChanged"
-             Loaded="List_Loaded">
-        <!-- set the template to disable the background change when the IsEnabled is false. -->
-        <ListBox.Template>
-            <ControlTemplate TargetType="{x:Type ListBox}">
-                <Border x:Name="Bd" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" Padding="1" SnapsToDevicePixels="true">
-                    <ScrollViewer Focusable="false" Padding="{TemplateBinding Padding}">
-                        <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                    </ScrollViewer>
-                </Border>                
-            </ControlTemplate>
-        </ListBox.Template>
-    </ListBox>
+    </Style>
+  </UserControl.Resources>
+  <ListBox
+    x:Name="_list"
+    Background="{DynamicResource {x:Static resx:Brushes.ListPaneBackground}}"
+    Foreground="{DynamicResource {x:Static resx:Brushes.UIText}}"
+    ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+    ScrollViewer.VerticalScrollBarVisibility="Visible"
+    ItemContainerStyleSelector="{DynamicResource itemStyleSelector}"
+    BorderThickness="0,0,0,1"
+    HorizontalContentAlignment="Stretch"
+    SelectionChanged="List_SelectionChanged"
+    Loaded="List_Loaded">
+    <!-- set the template to disable the background change when the IsEnabled is false. -->
+    <ListBox.Template>
+      <ControlTemplate
+        TargetType="{x:Type ListBox}">
+        <Border
+          x:Name="Bd"
+          BorderBrush="{TemplateBinding BorderBrush}"
+          BorderThickness="{TemplateBinding BorderThickness}"
+          Background="{TemplateBinding Background}"
+          Padding="1"
+          SnapsToDevicePixels="true">
+          <ScrollViewer
+            Focusable="false"
+            Padding="{TemplateBinding Padding}">
+            <ItemsPresenter
+              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+          </ScrollViewer>
+        </Border>
+      </ControlTemplate>
+    </ListBox.Template>
+  </ListBox>
 </UserControl>

--- a/src/PackageManagement.UI/Xamls/InstalledIndicator.xaml
+++ b/src/PackageManagement.UI/Xamls/InstalledIndicator.xaml
@@ -1,23 +1,31 @@
-﻿<UserControl x:Class="NuGet.PackageManagement.UI.InstalledIndicator"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             mc:Ignorable="d" 
-             d:DesignHeight="300" d:DesignWidth="300">
-    <Rectangle>
-        <Rectangle.Fill>
-            <DrawingBrush>
-                <DrawingBrush.Drawing>
-                    <DrawingGroup>
-                        <DrawingGroup.Children>
-                            <GeometryDrawing Brush="#FFF6F6F6" Geometry="F1M0,8C0,3.582 3.582,0 8,0 12.418,0 16,3.582 16,8 16,12.418 12.418,16 8,16 3.582,16 0,12.418 0,8" />
-                            <GeometryDrawing Brush="#FF329932" Geometry="F1M8,12L6,12 4,8 6,8 7,10 10,4 12,4z M8,1C4.135,1 1,4.134 1,8 1,11.865 4.135,15 8,15 11.865,15 15,11.865 15,8 15,4.134 11.865,1 8,1" />
-                            <GeometryDrawing Brush="#FFFFFFFF" Geometry="F1M12,4L8,12 6,12 4,8 6,8 7,10 10,4z" />
-                        </DrawingGroup.Children>
-                    </DrawingGroup>
-                </DrawingBrush.Drawing>
-            </DrawingBrush>
-        </Rectangle.Fill>
-    </Rectangle>
+﻿<UserControl
+  x:Class="NuGet.PackageManagement.UI.InstalledIndicator"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  mc:Ignorable="d"
+  d:DesignHeight="300"
+  d:DesignWidth="300">
+  <Rectangle>
+    <Rectangle.Fill>
+      <DrawingBrush>
+        <DrawingBrush.Drawing>
+          <DrawingGroup>
+            <DrawingGroup.Children>
+              <GeometryDrawing
+                Brush="#FFF6F6F6"
+                Geometry="F1M0,8C0,3.582 3.582,0 8,0 12.418,0 16,3.582 16,8 16,12.418 12.418,16 8,16 3.582,16 0,12.418 0,8" />
+              <GeometryDrawing
+                Brush="#FF329932"
+                Geometry="F1M8,12L6,12 4,8 6,8 7,10 10,4 12,4z M8,1C4.135,1 1,4.134 1,8 1,11.865 4.135,15 8,15 11.865,15 15,11.865 15,8 15,4.134 11.865,1 8,1" />
+              <GeometryDrawing
+                Brush="#FFFFFFFF"
+                Geometry="F1M12,4L8,12 6,12 4,8 6,8 7,10 10,4z" />
+            </DrawingGroup.Children>
+          </DrawingGroup>
+        </DrawingBrush.Drawing>
+      </DrawingBrush>
+    </Rectangle.Fill>
+  </Rectangle>
 </UserControl>

--- a/src/PackageManagement.UI/Xamls/InstalledIndicator.xaml.cs
+++ b/src/PackageManagement.UI/Xamls/InstalledIndicator.xaml.cs
@@ -1,17 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows.Controls;
 
 namespace NuGet.PackageManagement.UI
 {

--- a/src/PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml
+++ b/src/PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml
@@ -1,119 +1,143 @@
 ﻿<ui:VsDialogWindow
-    x:Class="NuGet.PackageManagement.UI.LicenseAcceptanceWindow"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"    
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
-    xmlns:ui="clr-namespace:NuGet.PackageManagement.UI"
-    x:Name="_self"
-    MinWidth="450"
-    MinHeight="450"
-    Width="450"
-    Height="450"
-    mc:Ignorable="d"
-    ShowInTaskbar="False"
-    WindowStartupLocation="CenterOwner"
-    Title="{x:Static resx:Resources.WindowTitle_LicenseAcceptance}"
-    d:DesignHeight="300" d:DesignWidth="300">
-    <Window.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="Resources.xaml" />
-            </ResourceDictionary.MergedDictionaries>
-            <DataTemplate x:Key="LicenseItemTemplate">
-                <StackPanel Margin="2,0,2,5">
-                    <TextBlock TextWrapping="Wrap">
-                    <Run Text="{Binding Id, Mode=OneTime}" FontWeight="Bold" />
-                    <Run Text=" " />
-                    <Run Text="Authors: " />
-                    <Run Text="{Binding Authors, Mode=OneTime}" />
-                    </TextBlock>
-                    <TextBlock AutomationProperties.AutomationId="{Binding Id, Mode=OneWay, StringFormat='LicenseTerm_{0}'}">
-                    <Hyperlink AutomationProperties.AutomationId="{Binding Id, Mode=OneWay, StringFormat='LicenseTermLink_{0}'}" 
-                               NavigateUri="{Binding LicenseUrl, Mode=OneTime}"  
-                               Style="{StaticResource HyperlinkStyle}"
-                               RequestNavigate="OnViewLicenseTermsRequestNavigate">
-                        <Run Text="View License" />
+  x:Class="NuGet.PackageManagement.UI.LicenseAcceptanceWindow"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
+  xmlns:ui="clr-namespace:NuGet.PackageManagement.UI"
+  x:Name="_self"
+  MinWidth="450"
+  MinHeight="450"
+  Width="450"
+  Height="450"
+  mc:Ignorable="d"
+  ShowInTaskbar="False"
+  WindowStartupLocation="CenterOwner"
+  Title="{x:Static resx:Resources.WindowTitle_LicenseAcceptance}"
+  d:DesignHeight="300"
+  d:DesignWidth="300">
+  <Window.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary
+          Source="Resources.xaml" />
+      </ResourceDictionary.MergedDictionaries>
+      <DataTemplate
+        x:Key="LicenseItemTemplate">
+        <StackPanel
+          Margin="2,0,2,5">
+          <TextBlock
+            TextWrapping="Wrap">
+                    <Run
+              Text="{Binding Id, Mode=OneTime}"
+              FontWeight="Bold" />
+                    <Run
+              Text=" " />
+                    <Run
+              Text="Authors: " />
+                    <Run
+              Text="{Binding Authors, Mode=OneTime}" />
+          </TextBlock>
+          <TextBlock
+            AutomationProperties.AutomationId="{Binding Id, Mode=OneWay, StringFormat='LicenseTerm_{0}'}">
+                    <Hyperlink
+              AutomationProperties.AutomationId="{Binding Id, Mode=OneWay, StringFormat='LicenseTermLink_{0}'}"
+              NavigateUri="{Binding LicenseUrl, Mode=OneTime}"
+              Style="{StaticResource HyperlinkStyle}"
+              RequestNavigate="OnViewLicenseTermsRequestNavigate">
+                        <Run
+                Text="View License" />
                     </Hyperlink>
-                    </TextBlock>
-                </StackPanel>
-            </DataTemplate>
-        </ResourceDictionary>        
-    </Window.Resources>
-    <Grid Background="White">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
-        <TextBlock 
-            Grid.Row="0"
-            Margin="12,8,12,0"
-            Text="{x:Static resx:Resources.Text_LicenseAcceptance}"
-            FontSize="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font122PercentSizeConverter}}" />
-        
-        <TextBlock
-            Grid.Row="1"
-            Margin="12,4,12,0"
-            Text="{x:Static resx:Resources.Text_LicenseHeaderText}" 
-            TextWrapping="Wrap"/>
-            
-        <ItemsControl
-            Grid.Row="2"
-            Margin="12,8"
-            MinHeight="130"
-            IsTabStop="False"
-            ItemsSource="{Binding}"
-            ItemTemplate="{StaticResource LicenseItemTemplate}">
-            <ItemsControl.Template>
-                <ControlTemplate TargetType="{x:Type ItemsControl}">
-                    <Border BorderThickness="1" BorderBrush="{DynamicResource {x:Static resx:Brushes.BorderBrush}}">
-                        <ScrollViewer
-                            Padding="3"
-                            Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
-                            CanContentScroll="True"
-                            VerticalScrollBarVisibility="Visible"
-                            HorizontalScrollBarVisibility="Disabled">
-                            <ItemsPresenter></ItemsPresenter>
-                        </ScrollViewer>
-                    </Border>
-                </ControlTemplate>
-            </ItemsControl.Template>
-        </ItemsControl>
-        <TextBlock Grid.Row="3"
-                   Margin="12,0,12,12"
-                   Text="{x:Static resx:Resources.Text_LicenseText}"
-                   TextWrapping="Wrap" ></TextBlock>
-        
-        <Grid 
-            Grid.Row="5"
-            Background="{Binding ElementName=_self, Path=Background}" >
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition />
-                <ColumnDefinition Width="auto" />
-                <ColumnDefinition Width="auto" />
-            </Grid.ColumnDefinitions>
-            
-            <Button
-                Grid.Column="1"
-                MinWidth="86"
-                MinHeight="24"
-                Margin="0,12"
-                Content="{x:Static resx:Resources.Button_IAccept}" 
-                AutomationProperties.AutomationId="AcceptButton"
-                Click="OnAcceptButtonClick" />
-            <Button 
-                Grid.Column="2"
-                MinWidth="86"
-                MinHeight="24"
-                Margin="6,12,12,12"
-                Content="{x:Static resx:Resources.Button_IDecline}" 
-                AutomationProperties.AutomationId="DeclineButton"
-                Click="OnDeclineButtonClick" />
+          </TextBlock>
+        </StackPanel>
+      </DataTemplate>
+    </ResourceDictionary>
+  </Window.Resources>
+  <Grid
+    Background="White">
+    <Grid.RowDefinitions>
+      <RowDefinition
+        Height="Auto" />
+      <RowDefinition
+        Height="Auto" />
+      <RowDefinition />
+      <RowDefinition
+        Height="Auto" />
+      <RowDefinition
+        Height="Auto" />
+    </Grid.RowDefinitions>
+    <TextBlock
+      Grid.Row="0"
+      Margin="12,8,12,0"
+      Text="{x:Static resx:Resources.Text_LicenseAcceptance}"
+      FontSize="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font122PercentSizeConverter}}" />
 
-        </Grid>
+    <TextBlock
+      Grid.Row="1"
+      Margin="12,4,12,0"
+      Text="{x:Static resx:Resources.Text_LicenseHeaderText}"
+      TextWrapping="Wrap" />
+
+    <ItemsControl
+      Grid.Row="2"
+      Margin="12,8"
+      MinHeight="130"
+      IsTabStop="False"
+      ItemsSource="{Binding}"
+      ItemTemplate="{StaticResource LicenseItemTemplate}">
+      <ItemsControl.Template>
+        <ControlTemplate
+          TargetType="{x:Type ItemsControl}">
+          <Border
+            BorderThickness="1"
+            BorderBrush="{DynamicResource {x:Static resx:Brushes.BorderBrush}}">
+            <ScrollViewer
+              Padding="3"
+              Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
+              CanContentScroll="True"
+              VerticalScrollBarVisibility="Visible"
+              HorizontalScrollBarVisibility="Disabled">
+              <ItemsPresenter></ItemsPresenter>
+            </ScrollViewer>
+          </Border>
+        </ControlTemplate>
+      </ItemsControl.Template>
+    </ItemsControl>
+    <TextBlock
+      Grid.Row="3"
+      Margin="12,0,12,12"
+      Text="{x:Static resx:Resources.Text_LicenseText}"
+      TextWrapping="Wrap"></TextBlock>
+
+    <Grid
+      Grid.Row="5"
+      Background="{Binding ElementName=_self, Path=Background}">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition />
+        <ColumnDefinition
+          Width="auto" />
+        <ColumnDefinition
+          Width="auto" />
+      </Grid.ColumnDefinitions>
+
+      <Button
+        Grid.Column="1"
+        MinWidth="86"
+        MinHeight="24"
+        Margin="0,12"
+        Content="{x:Static resx:Resources.Button_IAccept}"
+        AutomationProperties.AutomationId="AcceptButton"
+        Click="OnAcceptButtonClick" />
+      <Button
+        Grid.Column="2"
+        MinWidth="86"
+        MinHeight="24"
+        Margin="6,12,12,12"
+        Content="{x:Static resx:Resources.Button_IDecline}"
+        AutomationProperties.AutomationId="DeclineButton"
+        Click="OnDeclineButtonClick" />
+
     </Grid>
+  </Grid>
 </ui:VsDialogWindow>

--- a/src/PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml.cs
+++ b/src/PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml.cs
@@ -1,17 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
+﻿using System.Windows;
 using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace NuGet.PackageManagement.UI
 {

--- a/src/PackageManagement.UI/Xamls/OptionsControl.xaml.cs
+++ b/src/PackageManagement.UI/Xamls/OptionsControl.xaml.cs
@@ -1,17 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
+﻿using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace NuGet.PackageManagement.UI
 {

--- a/src/PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -1,105 +1,128 @@
-﻿<UserControl x:Class="NuGet.PackageManagement.UI.PackageItemControl"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             mc:Ignorable="d"
-             xmlns:ui="clr-namespace:NuGet.PackageManagement.UI"
-             xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
-             MinHeight="80"
-             d:DesignHeight="300" d:DesignWidth="300">
-    <UserControl.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="Resources.xaml" />
-            </ResourceDictionary.MergedDictionaries>
-            <ui:PackageStatusToInstallImageVisibilityConverter x:Key="PackageStatusToInstallImageVisibilityConverter" />
-            <ui:PackageStatusToUpdateImageVisibilityConverter x:Key="PackageStatusToUpdateImageVisibilityConverter" />
-            <ui:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />            
-        </ResourceDictionary>
-    </UserControl.Resources>
-    <Border
-            BorderThickness="0,0,0,1"
-            BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
-            Padding="0,16,0,15">
-        <Grid Margin="24,0,7,0">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
+﻿<UserControl
+  x:Class="NuGet.PackageManagement.UI.PackageItemControl"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  mc:Ignorable="d"
+  xmlns:ui="clr-namespace:NuGet.PackageManagement.UI"
+  xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
+  MinHeight="80"
+  d:DesignHeight="300"
+  d:DesignWidth="300">
+  <UserControl.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary
+          Source="Resources.xaml" />
+      </ResourceDictionary.MergedDictionaries>
+      <ui:PackageStatusToInstallImageVisibilityConverter
+        x:Key="PackageStatusToInstallImageVisibilityConverter" />
+      <ui:PackageStatusToUpdateImageVisibilityConverter
+        x:Key="PackageStatusToUpdateImageVisibilityConverter" />
+      <ui:BooleanToVisibilityConverter
+        x:Key="BooleanToVisibilityConverter" />
+    </ResourceDictionary>
+  </UserControl.Resources>
+  <Border
+    BorderThickness="0,0,0,1"
+    BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+    Padding="0,16,0,15">
+    <Grid
+      Margin="24,0,7,0">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition
+          Width="Auto" />
+        <ColumnDefinition />
+        <ColumnDefinition
+          Width="Auto" />
+      </Grid.ColumnDefinitions>
 
-            <!-- Icon -->
-            <Grid Grid.Column="0" VerticalAlignment="Top">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
-                <Image
-                    Grid.Row="0"
-                    Source="{Binding IconUrl,TargetNullValue={StaticResource BitmapImage_DefaultIcon}}"
-                    Height="32"
-                    Width="32"
-                    RenderOptions.BitmapScalingMode="HighQuality"
-                    Style="{StaticResource PackageIconImageStyle}"
-                    VerticalAlignment="Top"
-                    Margin="0,0,16,0" />
+      <!-- Icon -->
+      <Grid
+        Grid.Column="0"
+        VerticalAlignment="Top">
+        <Grid.RowDefinitions>
+          <RowDefinition
+            Height="Auto" />
+          <RowDefinition
+            Height="Auto" />
+        </Grid.RowDefinitions>
+        <Image
+          Grid.Row="0"
+          Source="{Binding IconUrl,TargetNullValue={StaticResource BitmapImage_DefaultIcon}}"
+          Height="32"
+          Width="32"
+          RenderOptions.BitmapScalingMode="HighQuality"
+          Style="{StaticResource PackageIconImageStyle}"
+          VerticalAlignment="Top"
+          Margin="0,0,16,0" />
 
-                <TextBlock Grid.Row="1"
-                           Text="{x:Static resx:Resources.Label_PackagePrerelease}"
-                           FontStyle="Italic"
-                           FontSize="9"
-                           Margin="0,3,0,0"
-                           HorizontalAlignment="Left"
-                           Visibility="{Binding Version.IsPrerelease, Converter={StaticResource BooleanToVisibilityConverter}}" />
-            </Grid>
+        <TextBlock
+          Grid.Row="1"
+          Text="{x:Static resx:Resources.Label_PackagePrerelease}"
+          FontStyle="Italic"
+          FontSize="9"
+          Margin="0,3,0,0"
+          HorizontalAlignment="Left"
+          Visibility="{Binding Version.IsPrerelease, Converter={StaticResource BooleanToVisibilityConverter}}" />
+      </Grid>
 
-            <!-- title & summary-->
-            <Grid Grid.Column="1" VerticalAlignment="Top" MinHeight="48">
-                <Grid.RowDefinitions>
-                    <RowDefinition />
-                    <RowDefinition Height="32" MaxHeight="32" />
-                </Grid.RowDefinitions>
-                <TextBlock
-                    Grid.Row="0"
-                    FontWeight="Bold"
-                    TextTrimming="CharacterEllipsis"
-                    TextWrapping="NoWrap"
-                    AutomationProperties.AutomationId="id"
-                    Text="{Binding Id}" />
-                <TextBlock
-                    Grid.Row="1"
-                    Text="{Binding Summary}"
-                    TextTrimming="CharacterEllipsis"
-                    TextWrapping="Wrap" />
+      <!-- title & summary-->
+      <Grid
+        Grid.Column="1"
+        VerticalAlignment="Top"
+        MinHeight="48">
+        <Grid.RowDefinitions>
+          <RowDefinition />
+          <RowDefinition
+            Height="32"
+            MaxHeight="32" />
+        </Grid.RowDefinitions>
+        <TextBlock
+          Grid.Row="0"
+          FontWeight="Bold"
+          TextTrimming="CharacterEllipsis"
+          TextWrapping="NoWrap"
+          AutomationProperties.AutomationId="id"
+          Text="{Binding Id}" />
+        <TextBlock
+          Grid.Row="1"
+          Text="{Binding Summary}"
+          TextTrimming="CharacterEllipsis"
+          TextWrapping="Wrap" />
 
-                <Grid.ToolTip>
-                    <TextBlock Style="{StaticResource TooltipStyle}" >
-                        <Run Text="{Binding Id}" FontWeight="Bold" />
-                        <LineBreak/>
-                        <Run Text="{Binding Summary}" />
-                    </TextBlock>
-                </Grid.ToolTip>
-            </Grid>
+        <Grid.ToolTip>
+          <TextBlock
+            Style="{StaticResource TooltipStyle}">
+                        <Run
+              Text="{Binding Id}"
+              FontWeight="Bold" />
+                        <LineBreak />
+                        <Run
+              Text="{Binding Summary}" />
+          </TextBlock>
+        </Grid.ToolTip>
+      </Grid>
 
-            <ui:InstalledIndicator
-                x:Name="_checkMark"
-                Grid.Column="2"
-                Margin="16,0,12,0"
-                Width="16"
-                Height="16"
-                VerticalAlignment="Top"
-                Visibility="{Binding Status, Converter={StaticResource PackageStatusToInstallImageVisibilityConverter}}"
-                ToolTip="{x:Static resx:Resources.Tooltip_PackageInstalled}" />
-            <ui:UpdateAvailableIndicator
-                x:Name="_updateMark"
-                Grid.Column="2"
-                Margin="16,0,12,0"
-                Width="16"
-                Height="16"
-                VerticalAlignment="Top"
-                Visibility="{Binding Status, Converter={StaticResource PackageStatusToUpdateImageVisibilityConverter}}"
-                ToolTip="{x:Static resx:Resources.Tooltip_UpdateAvailable}" />
-        </Grid>
-    </Border>
+      <ui:InstalledIndicator
+        x:Name="_checkMark"
+        Grid.Column="2"
+        Margin="16,0,12,0"
+        Width="16"
+        Height="16"
+        VerticalAlignment="Top"
+        Visibility="{Binding Status, Converter={StaticResource PackageStatusToInstallImageVisibilityConverter}}"
+        ToolTip="{x:Static resx:Resources.Tooltip_PackageInstalled}" />
+      <ui:UpdateAvailableIndicator
+        x:Name="_updateMark"
+        Grid.Column="2"
+        Margin="16,0,12,0"
+        Width="16"
+        Height="16"
+        VerticalAlignment="Top"
+        Visibility="{Binding Status, Converter={StaticResource PackageStatusToUpdateImageVisibilityConverter}}"
+        ToolTip="{x:Static resx:Resources.Tooltip_UpdateAvailable}" />
+    </Grid>
+  </Border>
 </UserControl>

--- a/src/PackageManagement.UI/Xamls/PackageManagerControl.xaml
+++ b/src/PackageManagement.UI/Xamls/PackageManagerControl.xaml
@@ -1,178 +1,222 @@
-﻿<UserControl x:Class="NuGet.PackageManagement.UI.PackageManagerControl"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:Tools="clr-namespace:NuGet.PackageManagement.UI"
-             xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
-             Background="{DynamicResource {x:Static resx:Brushes.HeaderBackground}}"
-             Foreground="{DynamicResource {x:Static resx:Brushes.UIText}}"
-             x:Name="_self"
-             mc:Ignorable="d"
-             d:DesignHeight="523" d:DesignWidth="900">
-    <UserControl.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="Resources.xaml" />
-            </ResourceDictionary.MergedDictionaries>
-        </ResourceDictionary>
-    </UserControl.Resources>
-    <UserControl.CommandBindings>
-        <CommandBinding
-            Command="{x:Static Tools:Commands.FocusOnSearchBox}"
-            Executed="FocusOnSearchBox_Executed" />
-    </UserControl.CommandBindings>
-    <UserControl.InputBindings>
-        <KeyBinding Command="{x:Static Tools:Commands.FocusOnSearchBox}" Gesture="CTRL+E" />
-    </UserControl.InputBindings>
-    <Grid>
-        <Grid x:Name="_root">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition />
-            </Grid.RowDefinitions>
-            <!-- Row 0 is used by restore bar -->
+﻿<UserControl
+  x:Class="NuGet.PackageManagement.UI.PackageManagerControl"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  xmlns:Tools="clr-namespace:NuGet.PackageManagement.UI"
+  xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
+  Background="{DynamicResource {x:Static resx:Brushes.HeaderBackground}}"
+  Foreground="{DynamicResource {x:Static resx:Brushes.UIText}}"
+  x:Name="_self"
+  mc:Ignorable="d"
+  d:DesignHeight="523"
+  d:DesignWidth="900">
+  <UserControl.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary
+          Source="Resources.xaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </UserControl.Resources>
+  <UserControl.CommandBindings>
+    <CommandBinding
+      Command="{x:Static Tools:Commands.FocusOnSearchBox}"
+      Executed="FocusOnSearchBox_Executed" />
+  </UserControl.CommandBindings>
+  <UserControl.InputBindings>
+    <KeyBinding
+      Command="{x:Static Tools:Commands.FocusOnSearchBox}"
+      Gesture="CTRL+E" />
+  </UserControl.InputBindings>
+  <Grid>
+    <Grid
+      x:Name="_root">
+      <Grid.RowDefinitions>
+        <RowDefinition
+          Height="Auto" />
+        <RowDefinition
+          Height="Auto" />
+        <RowDefinition
+          Height="Auto" />
+        <RowDefinition />
+      </Grid.RowDefinitions>
+      <!-- Row 0 is used by restore bar -->
 
+      <TextBlock
+        Grid.Row="1"
+        x:Name="_label"
+        FontSize="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font155PercentSizeConverter}}"
+        Margin="8,8">Package Manager</TextBlock>
+
+      <WrapPanel
+        Grid.Row="2"
+        Margin="0,12,0,20"
+        Orientation="Horizontal">
+        <StackPanel
+          Orientation="Horizontal"
+          Margin="24,8,0,0">
+          <TextBlock
+            Grid.Column="0"
+            VerticalAlignment="Center"
+            Text="{x:Static resx:Resources.Label_Repository}" />
+
+          <ComboBox
+            Margin="6,0,0,0"
+            x:Name="_sourceRepoList"
+            VerticalAlignment="Center"
+            DisplayMemberPath="PackageSource.Name"
+            MinWidth="130"
+            MinHeight="22"
+            Grid.Column="1"
+            AutomationProperties.Name="{x:Static resx:Resources.Label_Repository}"
+            SelectionChanged="SourceRepoList_SelectionChanged">
+            <ComboBox.ToolTip>
+              <ToolTip
+                x:Name="_sourceTooltip">
+                <TextBlock
+                  Text="{Binding}" />
+              </ToolTip>
+            </ComboBox.ToolTip>
+          </ComboBox>
+
+          <TextBlock
+            Grid.Column="2"
+            Margin="24,0,0,0"
+            VerticalAlignment="Center"
+            Text="{x:Static resx:Resources.Label_Filter}" />
+
+          <ComboBox
+            Grid.Column="3"
+            Margin="6,0,0,0"
+            VerticalAlignment="Center"
+            SelectedIndex="0"
+            x:Name="_filter"
+            MinWidth="130"
+            MinHeight="22"
+            AutomationProperties.Name="{x:Static resx:Resources.Label_Filter}"
+            SelectionChanged="Filter_SelectionChanged" />
+
+          <CheckBox
+            x:Name="_checkboxPrerelease"
+            Grid.Column="4"
+            Margin="24,0,0,0"
+            VerticalAlignment="Center"
+            Content="{x:Static resx:Resources.Checkbox_IncludePrerelease}"
+            Foreground="{DynamicResource {x:Static resx:Brushes.UIText}}"
+            VerticalContentAlignment="Center"
+            Checked="CheckboxPrerelease_CheckChanged"
+            Unchecked="CheckboxPrerelease_CheckChanged"
+            IsChecked="True" />
+        </StackPanel>
+
+        <StackPanel
+          Orientation="Horizontal"
+          Margin="24,8,0,0"
+          MinHeight="24">
+          <Border
+            Grid.Column="6"
+            VerticalAlignment="Center"
+            x:Name="_searchControlParent"
+            MinHeight="22"
+            MinWidth="224"
+            MaxWidth="224" />
+
+          <Button
+            Margin="24,0"
+            VerticalAlignment="Center"
+            Padding="0"
+            Grid.Column="7"
+            Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}"
+            Click="SettingsButtonClick"
+            x:Name="_settingsButton">
+            <Rectangle
+              Width="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font122PercentSizeConverter}}"
+              Height="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font122PercentSizeConverter}}">
+              <Rectangle.Fill>
+                <DrawingBrush>
+                  <DrawingBrush.Drawing>
+                    <DrawingGroup>
+                      <DrawingGroup.Children>
+                        <GeometryDrawing
+                          Brush="#00FFFFFF"
+                          Geometry="F1M16,16L0,16 0,0 16,0z" />
+                        <GeometryDrawing
+                          Brush="#FFF6F6F6"
+                          Geometry="F1M15.9434,7.0796L15.8734,6.4596 13.6374,5.6646 14.6544,3.5256 14.2684,3.0376C13.8854,2.5536,13.4464,2.1146,12.9644,1.7316L12.4754,1.3456 10.3354,2.3626 9.5414,0.1286 8.9224,0.057599999999999C8.6194,0.0215999999999994 8.3124,-0.000400000000000844 8.0004,-0.000400000000000844 7.6894,-0.000400000000000844 7.3824,0.0215999999999994 7.0804,0.0565999999999995L6.4614,0.126599999999999 5.6664,2.3626 3.5254,1.3456 3.0374,1.7316C2.5554,2.1126,2.1164,2.5516,1.7324,3.0366L1.3454,3.5246 2.3624,5.6646 0.1274,6.4596 0.0564,7.0796C0.0224000000000011,7.3816 0.000400000000000844,7.6876 0.000400000000000844,7.9996 0.000400000000000844,8.3116 0.0224000000000011,8.6186 0.0564,8.9206L0.1274,9.5396 2.3624,10.3346 1.3454,12.4746 1.7324,12.9626C2.1144,13.4466,2.5534,13.8846,3.0374,14.2676L3.5254,14.6556 5.6664,13.6376 6.4614,15.8726 7.0804,15.9436C7.3824,15.9786 7.6894,15.9996 8.0004,15.9996 8.3134,15.9996 8.6204,15.9786 8.9244,15.9426L9.5424,15.8706 10.3364,13.6366 12.4754,14.6556 12.9644,14.2676C13.4484,13.8836,13.8874,13.4446,14.2684,12.9616L14.6544,12.4736 13.6374,10.3346 15.8734,9.5396 15.9434,8.9206C15.9784,8.6186 16.0004,8.3116 16.0004,7.9996 16.0004,7.6876 15.9784,7.3816 15.9434,7.0796" />
+                        <GeometryDrawing
+                          Brush="#FF414141"
+                          Geometry="F1M8,5C6.343,5 5,6.343 5,8 5,9.657 6.343,11 8,11 9.657,11 11,9.657 11,8 11,6.343 9.657,5 8,5 M12.714,9.603C12.644,9.81,12.563,10.01,12.468,10.203L13.484,12.342C13.149,12.766,12.767,13.148,12.343,13.484L10.203,12.467C10.01,12.563,9.81,12.643,9.603,12.714L8.808,14.949C8.542,14.98 8.273,15 8,15 7.728,15 7.459,14.98 7.194,14.95L6.399,12.715C6.192,12.644,5.991,12.564,5.798,12.468L3.658,13.484C3.234,13.148,2.852,12.766,2.516,12.342L3.532,10.203C3.437,10.01,3.356,9.81,3.286,9.603L1.05,8.807C1.02,8.542 1,8.273 1,8 1,7.727 1.02,7.458 1.05,7.193L3.286,6.397C3.356,6.19,3.437,5.991,3.532,5.797L2.516,3.658C2.852,3.234,3.234,2.851,3.658,2.516L5.798,3.532C5.991,3.436,6.191,3.356,6.399,3.286L7.194,1.05C7.459,1.02 7.728,1 8,1 8.273,1 8.542,1.02 8.808,1.05L9.603,3.287C9.81,3.357,10.01,3.437,10.203,3.533L12.343,2.516C12.767,2.852,13.149,3.235,13.484,3.658L12.468,5.797C12.563,5.991,12.644,6.19,12.714,6.397L14.95,7.193C14.98,7.458 15,7.727 15,8 15,8.273 14.98,8.542 14.95,8.807z" />
+                        <GeometryDrawing
+                          Brush="#FF414141"
+                          Geometry="F1M9.5,8C9.5,8.828 8.829,9.5 8,9.5 7.171,9.5 6.5,8.828 6.5,8 6.5,7.172 7.171,6.5 8,6.5 8.829,6.5 9.5,7.172 9.5,8" />
+                        <GeometryDrawing
+                          Brush="#FFF0EFF1"
+                          Geometry="F1M8,9.5C7.172,9.5 6.5,8.828 6.5,8 6.5,7.172 7.172,6.5 8,6.5 8.828,6.5 9.5,7.172 9.5,8 9.5,8.828 8.828,9.5 8,9.5 M8,5C6.343,5 5,6.343 5,8 5,9.656 6.343,11 8,11 9.657,11 11,9.656 11,8 11,6.343 9.657,5 8,5" />
+                      </DrawingGroup.Children>
+                    </DrawingGroup>
+                  </DrawingBrush.Drawing>
+                </DrawingBrush>
+              </Rectangle.Fill>
+            </Rectangle>
+          </Button>
+        </StackPanel>
+      </WrapPanel>
+      <Border
+        Grid.Row="3"
+        BorderThickness="0,1,0,0"
+        BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}">
+        <Grid>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition
+              MinWidth="300" />
+            <ColumnDefinition
+              Width="auto" />
+            <ColumnDefinition
+              MinWidth="300" />
+          </Grid.ColumnDefinitions>
+          <Grid.RowDefinitions>
+            <RowDefinition />
+            <RowDefinition
+              Height="Auto" />
+          </Grid.RowDefinitions>
+          <Tools:InfiniteScrollList
+            x:Name="_packageList"
+            SelectionChanged="PackageList_SelectionChanged">
+          </Tools:InfiniteScrollList>
+
+          <StackPanel
+            Grid.Row="1"
+            Grid.Column="0"
+            Orientation="Vertical"
+            x:Name="_legalDisclaimer"
+            Background="{DynamicResource {x:Static resx:Brushes.LegalMessageBackground}}">
             <TextBlock
-                Grid.Row="1"
-                x:Name="_label"
-                FontSize="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font155PercentSizeConverter}}"
-                Margin="8,8">Package Manager</TextBlock>
+              Margin="24,12,24,12"
+              TextWrapping="Wrap"
+              Text="{x:Static resx:Resources.Text_LegalDisclaimer}" />
+            <CheckBox
+              Margin="24,0,24,12"
+              Foreground="{DynamicResource {x:Static resx:Brushes.UIText}}"
+              Content="{x:Static resx:Resources.Checkbox_DoNotShowThisAgain}"
+              Checked="SuppressDisclaimerChecked" />
+          </StackPanel>
 
-            <WrapPanel Grid.Row="2" Margin="0,12,0,20" Orientation="Horizontal">
-                <StackPanel Orientation="Horizontal" Margin="24,8,0,0">
-                    <TextBlock
-                        Grid.Column="0"
-                        VerticalAlignment="Center"
-                        Text="{x:Static resx:Resources.Label_Repository}" />
-
-                    <ComboBox
-                        Margin="6,0,0,0"
-                        x:Name="_sourceRepoList"
-                        VerticalAlignment="Center"
-                        DisplayMemberPath="PackageSource.Name"
-                        MinWidth="130"
-                        MinHeight="22"
-                        Grid.Column="1"
-                        AutomationProperties.Name="{x:Static resx:Resources.Label_Repository}"
-                        SelectionChanged="SourceRepoList_SelectionChanged">
-                        <ComboBox.ToolTip>
-                            <ToolTip x:Name="_sourceTooltip" >
-                                <TextBlock Text="{Binding}" />
-                            </ToolTip>
-                        </ComboBox.ToolTip>
-                    </ComboBox>
-
-                    <TextBlock
-                        Grid.Column="2"
-                        Margin="24,0,0,0"
-                        VerticalAlignment="Center"
-                        Text="{x:Static resx:Resources.Label_Filter}" />
-
-                    <ComboBox
-                        Grid.Column="3"
-                        Margin="6,0,0,0"
-                        VerticalAlignment="Center"
-                        SelectedIndex="0"
-                        x:Name="_filter"
-                        MinWidth="130"
-                        MinHeight="22"
-                        AutomationProperties.Name="{x:Static resx:Resources.Label_Filter}"
-                        SelectionChanged="Filter_SelectionChanged" />
-
-                    <CheckBox
-                        x:Name="_checkboxPrerelease"
-                        Grid.Column="4" Margin="24,0,0,0"
-                        VerticalAlignment="Center"
-                        Content="{x:Static resx:Resources.Checkbox_IncludePrerelease}"
-                        Foreground="{DynamicResource {x:Static resx:Brushes.UIText}}"
-                        VerticalContentAlignment="Center"
-                        Checked="CheckboxPrerelease_CheckChanged"
-                        Unchecked="CheckboxPrerelease_CheckChanged" IsChecked="True" />
-                </StackPanel>
-
-                <StackPanel Orientation="Horizontal" Margin="24,8,0,0" MinHeight="24">
-                    <Border
-                        Grid.Column="6"
-                        VerticalAlignment="Center"
-                        x:Name="_searchControlParent"
-                        MinHeight="22"
-                        MinWidth="224"
-                        MaxWidth="224"/>
-
-                    <Button
-                        Margin="24,0"
-                        VerticalAlignment="Center"
-                        Padding="0"
-                        Grid.Column="7"
-                        Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}"
-                        Click="SettingsButtonClick" x:Name="_settingsButton">
-                        <Rectangle
-                            Width="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font122PercentSizeConverter}}"
-                            Height="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font122PercentSizeConverter}}">
-                            <Rectangle.Fill>
-                                <DrawingBrush>
-                                    <DrawingBrush.Drawing>
-                                        <DrawingGroup>
-                                            <DrawingGroup.Children>
-                                                <GeometryDrawing Brush="#00FFFFFF" Geometry="F1M16,16L0,16 0,0 16,0z" />
-                                                <GeometryDrawing Brush="#FFF6F6F6" Geometry="F1M15.9434,7.0796L15.8734,6.4596 13.6374,5.6646 14.6544,3.5256 14.2684,3.0376C13.8854,2.5536,13.4464,2.1146,12.9644,1.7316L12.4754,1.3456 10.3354,2.3626 9.5414,0.1286 8.9224,0.057599999999999C8.6194,0.0215999999999994 8.3124,-0.000400000000000844 8.0004,-0.000400000000000844 7.6894,-0.000400000000000844 7.3824,0.0215999999999994 7.0804,0.0565999999999995L6.4614,0.126599999999999 5.6664,2.3626 3.5254,1.3456 3.0374,1.7316C2.5554,2.1126,2.1164,2.5516,1.7324,3.0366L1.3454,3.5246 2.3624,5.6646 0.1274,6.4596 0.0564,7.0796C0.0224000000000011,7.3816 0.000400000000000844,7.6876 0.000400000000000844,7.9996 0.000400000000000844,8.3116 0.0224000000000011,8.6186 0.0564,8.9206L0.1274,9.5396 2.3624,10.3346 1.3454,12.4746 1.7324,12.9626C2.1144,13.4466,2.5534,13.8846,3.0374,14.2676L3.5254,14.6556 5.6664,13.6376 6.4614,15.8726 7.0804,15.9436C7.3824,15.9786 7.6894,15.9996 8.0004,15.9996 8.3134,15.9996 8.6204,15.9786 8.9244,15.9426L9.5424,15.8706 10.3364,13.6366 12.4754,14.6556 12.9644,14.2676C13.4484,13.8836,13.8874,13.4446,14.2684,12.9616L14.6544,12.4736 13.6374,10.3346 15.8734,9.5396 15.9434,8.9206C15.9784,8.6186 16.0004,8.3116 16.0004,7.9996 16.0004,7.6876 15.9784,7.3816 15.9434,7.0796" />
-                                                <GeometryDrawing Brush="#FF414141" Geometry="F1M8,5C6.343,5 5,6.343 5,8 5,9.657 6.343,11 8,11 9.657,11 11,9.657 11,8 11,6.343 9.657,5 8,5 M12.714,9.603C12.644,9.81,12.563,10.01,12.468,10.203L13.484,12.342C13.149,12.766,12.767,13.148,12.343,13.484L10.203,12.467C10.01,12.563,9.81,12.643,9.603,12.714L8.808,14.949C8.542,14.98 8.273,15 8,15 7.728,15 7.459,14.98 7.194,14.95L6.399,12.715C6.192,12.644,5.991,12.564,5.798,12.468L3.658,13.484C3.234,13.148,2.852,12.766,2.516,12.342L3.532,10.203C3.437,10.01,3.356,9.81,3.286,9.603L1.05,8.807C1.02,8.542 1,8.273 1,8 1,7.727 1.02,7.458 1.05,7.193L3.286,6.397C3.356,6.19,3.437,5.991,3.532,5.797L2.516,3.658C2.852,3.234,3.234,2.851,3.658,2.516L5.798,3.532C5.991,3.436,6.191,3.356,6.399,3.286L7.194,1.05C7.459,1.02 7.728,1 8,1 8.273,1 8.542,1.02 8.808,1.05L9.603,3.287C9.81,3.357,10.01,3.437,10.203,3.533L12.343,2.516C12.767,2.852,13.149,3.235,13.484,3.658L12.468,5.797C12.563,5.991,12.644,6.19,12.714,6.397L14.95,7.193C14.98,7.458 15,7.727 15,8 15,8.273 14.98,8.542 14.95,8.807z" />
-                                                <GeometryDrawing Brush="#FF414141" Geometry="F1M9.5,8C9.5,8.828 8.829,9.5 8,9.5 7.171,9.5 6.5,8.828 6.5,8 6.5,7.172 7.171,6.5 8,6.5 8.829,6.5 9.5,7.172 9.5,8" />
-                                                <GeometryDrawing Brush="#FFF0EFF1" Geometry="F1M8,9.5C7.172,9.5 6.5,8.828 6.5,8 6.5,7.172 7.172,6.5 8,6.5 8.828,6.5 9.5,7.172 9.5,8 9.5,8.828 8.828,9.5 8,9.5 M8,5C6.343,5 5,6.343 5,8 5,9.656 6.343,11 8,11 9.657,11 11,9.656 11,8 11,6.343 9.657,5 8,5" />
-                                            </DrawingGroup.Children>
-                                        </DrawingGroup>
-                                    </DrawingBrush.Drawing>
-                                </DrawingBrush>
-                            </Rectangle.Fill>
-                        </Rectangle>
-                    </Button>
-                </StackPanel>
-            </WrapPanel>
-            <Border Grid.Row="3" BorderThickness="0,1,0,0" BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}">
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition MinWidth="300" />
-                        <ColumnDefinition Width="auto" />
-                        <ColumnDefinition MinWidth="300" />
-                    </Grid.ColumnDefinitions>
-                    <Grid.RowDefinitions>
-                        <RowDefinition />
-                        <RowDefinition Height="Auto" />
-                    </Grid.RowDefinitions>
-                    <Tools:InfiniteScrollList x:Name="_packageList" SelectionChanged="PackageList_SelectionChanged">
-                    </Tools:InfiniteScrollList>
-
-                    <StackPanel
-                        Grid.Row="1"
-                        Grid.Column="0"
-                        Orientation="Vertical"
-                        x:Name="_legalDisclaimer"
-                        Background="{DynamicResource {x:Static resx:Brushes.LegalMessageBackground}}">
-                        <TextBlock
-                            Margin="24,12,24,12"
-                            TextWrapping="Wrap"
-                            Text="{x:Static resx:Resources.Text_LegalDisclaimer}" />
-                        <CheckBox 
-                            Margin="24,0,24,12"
-                            Foreground="{DynamicResource {x:Static resx:Brushes.UIText}}"
-                            Content="{x:Static resx:Resources.Checkbox_DoNotShowThisAgain}" Checked="SuppressDisclaimerChecked"/>
-                    </StackPanel>
-
-                    <GridSplitter Grid.Column="1" Width="5"
-                                  Grid.RowSpan="2"
-                                  HorizontalAlignment="Center"
-                                  VerticalAlignment="Stretch"
-                                  BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
-                                  BorderThickness="1,0" />
-                    <Tools:DetailControl
-                        x:Name="_packageDetail"
-                        Grid.Column="2"
-                        Grid.RowSpan="2" />
-                </Grid>
-            </Border>
+          <GridSplitter
+            Grid.Column="1"
+            Width="5"
+            Grid.RowSpan="2"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Stretch"
+            BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+            BorderThickness="1,0" />
+          <Tools:DetailControl
+            x:Name="_packageDetail"
+            Grid.Column="2"
+            Grid.RowSpan="2" />
         </Grid>
+      </Border>
     </Grid>
+  </Grid>
 </UserControl>

--- a/src/PackageManagement.UI/Xamls/PackageMetadataControl.xaml
+++ b/src/PackageManagement.UI/Xamls/PackageMetadataControl.xaml
@@ -1,64 +1,73 @@
-﻿<UserControl x:Class="NuGet.PackageManagement.UI.PackageMetadataControl"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
-             xmlns:Tools="clr-namespace:NuGet.PackageManagement.UI"
-             Background="{DynamicResource {x:Static resx:Brushes.DetailPaneBackground}}"
-             Foreground="{DynamicResource {x:Static resx:Brushes.UIText}}"
-             mc:Ignorable="d"
-             d:DesignHeight="300" d:DesignWidth="300">
-    <UserControl.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="Resources.xaml" />
-            </ResourceDictionary.MergedDictionaries>
-        </ResourceDictionary>
-    </UserControl.Resources>
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
+﻿<UserControl
+  x:Class="NuGet.PackageManagement.UI.PackageMetadataControl"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
+  xmlns:Tools="clr-namespace:NuGet.PackageManagement.UI"
+  Background="{DynamicResource {x:Static resx:Brushes.DetailPaneBackground}}"
+  Foreground="{DynamicResource {x:Static resx:Brushes.UIText}}"
+  mc:Ignorable="d"
+  d:DesignHeight="300"
+  d:DesignWidth="300">
+  <UserControl.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary
+          Source="Resources.xaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </UserControl.Resources>
+  <Grid>
+    <Grid.RowDefinitions>
+      <RowDefinition
+        Height="Auto" />
+      <RowDefinition
+        Height="Auto" />
+      <RowDefinition
+        Height="Auto" />
+      <RowDefinition
+        Height="Auto" />
+    </Grid.RowDefinitions>
 
-        <!-- descriptions -->
-        <TextBlock
-                Grid.Row="0"
-                Text="{x:Static resx:Resources.Label_Description}"
-                FontWeight="Bold" />
-        <TextBlock
-                Grid.Row="1"
-                x:Name="_description"
-                Margin="0,8,0,0"
-                TextWrapping="Wrap"
-                Text="{Binding Path=Description}" />
+    <!-- descriptions -->
+    <TextBlock
+      Grid.Row="0"
+      Text="{x:Static resx:Resources.Label_Description}"
+      FontWeight="Bold" />
+    <TextBlock
+      Grid.Row="1"
+      x:Name="_description"
+      Margin="0,8,0,0"
+      TextWrapping="Wrap"
+      Text="{Binding Path=Description}" />
 
-        <!-- metadata -->
-        <Grid
-                Grid.Row="2"
-                x:Name="_metadataGrid"
-                Margin="0,8">
-            <Grid.RowDefinitions>
-                <!-- place holder for Owners/Publishers -->
-                <RowDefinition Height="0" />
-                
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-            </Grid.RowDefinitions>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition />
-            </Grid.ColumnDefinitions>
+    <!-- metadata -->
+    <Grid
+      Grid.Row="2"
+      x:Name="_metadataGrid"
+      Margin="0,8">
+      <Grid.RowDefinitions>
+        <!-- place holder for Owners/Publishers -->
+        <RowDefinition
+          Height="0" />
 
-            <!-- Publisher(s) 
+        <RowDefinition />
+        <RowDefinition />
+        <RowDefinition />
+        <RowDefinition />
+        <RowDefinition />
+        <RowDefinition />
+        <RowDefinition />
+      </Grid.RowDefinitions>
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition
+          Width="Auto" />
+        <ColumnDefinition />
+      </Grid.ColumnDefinitions>
+
+      <!-- Publisher(s) 
             <TextBlock
                         Visibility="{Binding Path=Owners,Converter={StaticResource NullToVisibilityConverter}}"
                         Grid.Row="0" Grid.Column="0" FontWeight="Bold"
@@ -72,154 +81,189 @@
                         Grid.Row="0" Grid.Column="1" />
             -->
 
-            <!-- Author(s) -->
-            <TextBlock
-                        Visibility="{Binding Path=Authors,Converter={StaticResource NullToVisibilityConverter}}"
-                        Grid.Row="1" Grid.Column="0"
-                        Margin="0,8,0,0"
-                        FontWeight="Bold"
-                        Text="{x:Static resx:Resources.Label_Authors}" />
-            <TextBlock
-                        Visibility="{Binding Path=Authors,Converter={StaticResource NullToVisibilityConverter}}"
-                        Text="{Binding Path=Authors}"
-                        Margin="8,8,0,0"
-                        TextWrapping="Wrap"
-                        Grid.Row="1" Grid.Column="1"></TextBlock>
+      <!-- Author(s) -->
+      <TextBlock
+        Visibility="{Binding Path=Authors,Converter={StaticResource NullToVisibilityConverter}}"
+        Grid.Row="1"
+        Grid.Column="0"
+        Margin="0,8,0,0"
+        FontWeight="Bold"
+        Text="{x:Static resx:Resources.Label_Authors}" />
+      <TextBlock
+        Visibility="{Binding Path=Authors,Converter={StaticResource NullToVisibilityConverter}}"
+        Text="{Binding Path=Authors}"
+        Margin="8,8,0,0"
+        TextWrapping="Wrap"
+        Grid.Row="1"
+        Grid.Column="1"></TextBlock>
 
-            <!-- License -->
-            <TextBlock
-                        Visibility="{Binding Path=LicenseUrl,Converter={StaticResource NullToVisibilityConverter}}"
-                        Grid.Row="2" Grid.Column="0" FontWeight="Bold"
-                        Margin="0,8,0,0"
-                        Text="{x:Static resx:Resources.Label_License}" />
-            <TextBlock
-                        Visibility="{Binding Path=LicenseUrl,Converter={StaticResource NullToVisibilityConverter}}"
-                        TextWrapping="Wrap"
-                        Margin="8,8,0,0"
-                        Grid.Row="2" Grid.Column="1">
-                        <Hyperlink NavigateUri="{Binding Path=LicenseUrl}"
-                                   Style="{StaticResource HyperlinkStyle}"
-                                   Command="{x:Static Tools:PackageManagerControlCommands.OpenExternalLink}">
-                            <Run Text="{Binding Path=LicenseUrl}" />
+      <!-- License -->
+      <TextBlock
+        Visibility="{Binding Path=LicenseUrl,Converter={StaticResource NullToVisibilityConverter}}"
+        Grid.Row="2"
+        Grid.Column="0"
+        FontWeight="Bold"
+        Margin="0,8,0,0"
+        Text="{x:Static resx:Resources.Label_License}" />
+      <TextBlock
+        Visibility="{Binding Path=LicenseUrl,Converter={StaticResource NullToVisibilityConverter}}"
+        TextWrapping="Wrap"
+        Margin="8,8,0,0"
+        Grid.Row="2"
+        Grid.Column="1">
+                        <Hyperlink
+          NavigateUri="{Binding Path=LicenseUrl}"
+          Style="{StaticResource HyperlinkStyle}"
+          Command="{x:Static Tools:PackageManagerControlCommands.OpenExternalLink}">
+                            <Run
+            Text="{Binding Path=LicenseUrl}" />
                         </Hyperlink>
-            </TextBlock>
+      </TextBlock>
 
-            <!-- downloads -->
-            <TextBlock
-                        Visibility="{Binding Path=DownloadCount,Converter={StaticResource  DownloadCountToVisibilityConverter}}"
-                        Grid.Row="3" Grid.Column="0" FontWeight="Bold"
-                        Margin="0,8,0,0"
-                        Text="{x:Static resx:Resources.Label_Downloads}" />
-            <TextBlock
-                        Visibility="{Binding Path=DownloadCount,Converter={StaticResource DownloadCountToVisibilityConverter}}"
-                        Text="{Binding Path=DownloadCount,StringFormat={}{0:N0}}"
-                        Margin="8,8,0,0"
-                        TextWrapping="Wrap"
-                        Grid.Row="3" Grid.Column="1"></TextBlock>
+      <!-- downloads -->
+      <TextBlock
+        Visibility="{Binding Path=DownloadCount,Converter={StaticResource  DownloadCountToVisibilityConverter}}"
+        Grid.Row="3"
+        Grid.Column="0"
+        FontWeight="Bold"
+        Margin="0,8,0,0"
+        Text="{x:Static resx:Resources.Label_Downloads}" />
+      <TextBlock
+        Visibility="{Binding Path=DownloadCount,Converter={StaticResource DownloadCountToVisibilityConverter}}"
+        Text="{Binding Path=DownloadCount,StringFormat={}{0:N0}}"
+        Margin="8,8,0,0"
+        TextWrapping="Wrap"
+        Grid.Row="3"
+        Grid.Column="1"></TextBlock>
 
-            <!--Date Published -->
-            <TextBlock
-                        Visibility="{Binding Path=Published,Converter={StaticResource NullToVisibilityConverter}}"
-                        Grid.Row="4" Grid.Column="0" FontWeight="Bold"
-                        Margin="0,8,0,0"
-                        Text="{x:Static resx:Resources.Label_DatePublished}" />
-            <TextBlock
-                        Visibility="{Binding Path=Published,Converter={StaticResource NullToVisibilityConverter}}"
-                        Text="{Binding Path=Published,StringFormat={}{0:D} ({0:d})}"
-                        Margin="8,8,0,0"
-                        TextWrapping="Wrap"
-                        Grid.Row="4" Grid.Column="1"></TextBlock>
+      <!--Date Published -->
+      <TextBlock
+        Visibility="{Binding Path=Published,Converter={StaticResource NullToVisibilityConverter}}"
+        Grid.Row="4"
+        Grid.Column="0"
+        FontWeight="Bold"
+        Margin="0,8,0,0"
+        Text="{x:Static resx:Resources.Label_DatePublished}" />
+      <TextBlock
+        Visibility="{Binding Path=Published,Converter={StaticResource NullToVisibilityConverter}}"
+        Text="{Binding Path=Published,StringFormat={}{0:D} ({0:d})}"
+        Margin="8,8,0,0"
+        TextWrapping="Wrap"
+        Grid.Row="4"
+        Grid.Column="1"></TextBlock>
 
-            <!-- Project Url -->
-            <TextBlock
-                        Visibility="{Binding Path=ProjectUrl,Converter={StaticResource NullToVisibilityConverter}}"
-                        Grid.Row="5" Grid.Column="0" FontWeight="Bold"
-                        Margin="0,8,0,0"
-                        Text="{x:Static resx:Resources.Label_ProjectUrl}" />
+      <!-- Project Url -->
+      <TextBlock
+        Visibility="{Binding Path=ProjectUrl,Converter={StaticResource NullToVisibilityConverter}}"
+        Grid.Row="5"
+        Grid.Column="0"
+        FontWeight="Bold"
+        Margin="0,8,0,0"
+        Text="{x:Static resx:Resources.Label_ProjectUrl}" />
 
-            <TextBlock
-                        Visibility="{Binding Path=ProjectUrl,Converter={StaticResource NullToVisibilityConverter}}"
-                        TextWrapping="Wrap"
-                        Margin="8,8,0,0"
-                        Grid.Row="5" Grid.Column="1">
-                        <Hyperlink NavigateUri="{Binding Path=ProjectUrl}"
-                                   Style="{StaticResource HyperlinkStyle}"
-                                   Command="{x:Static Tools:PackageManagerControlCommands.OpenExternalLink}">
-                            <Run Text="{Binding Path=ProjectUrl}" />
+      <TextBlock
+        Visibility="{Binding Path=ProjectUrl,Converter={StaticResource NullToVisibilityConverter}}"
+        TextWrapping="Wrap"
+        Margin="8,8,0,0"
+        Grid.Row="5"
+        Grid.Column="1">
+                        <Hyperlink
+          NavigateUri="{Binding Path=ProjectUrl}"
+          Style="{StaticResource HyperlinkStyle}"
+          Command="{x:Static Tools:PackageManagerControlCommands.OpenExternalLink}">
+                            <Run
+            Text="{Binding Path=ProjectUrl}" />
                         </Hyperlink>
-            </TextBlock>
+      </TextBlock>
 
-            <!-- Report abuse Url -->
-            <TextBlock
-                        Visibility="{Binding Path=ReportAbuseUrl,Converter={StaticResource NullToVisibilityConverter}}"
-                        Grid.Row="6" Grid.Column="0" FontWeight="Bold"
-                        Margin="0,8,0,0"
-                        Text="{x:Static resx:Resources.Label_ReportAbuse}" />
+      <!-- Report abuse Url -->
+      <TextBlock
+        Visibility="{Binding Path=ReportAbuseUrl,Converter={StaticResource NullToVisibilityConverter}}"
+        Grid.Row="6"
+        Grid.Column="0"
+        FontWeight="Bold"
+        Margin="0,8,0,0"
+        Text="{x:Static resx:Resources.Label_ReportAbuse}" />
 
-            <TextBlock
-                        Visibility="{Binding Path=ReportAbuseUrl,Converter={StaticResource NullToVisibilityConverter}}"
-                        TextWrapping="Wrap"
-                        Margin="8,8,0,0"
-                        Grid.Row="6" Grid.Column="1">
-                <Hyperlink NavigateUri="{Binding Path=ReportAbuseUrl}"
-                           Style="{StaticResource HyperlinkStyle}"
-                           Command="{x:Static Tools:PackageManagerControlCommands.OpenExternalLink}">
-                    <Run Text="{Binding Path=ReportAbuseUrl}" />
+      <TextBlock
+        Visibility="{Binding Path=ReportAbuseUrl,Converter={StaticResource NullToVisibilityConverter}}"
+        TextWrapping="Wrap"
+        Margin="8,8,0,0"
+        Grid.Row="6"
+        Grid.Column="1">
+                <Hyperlink
+          NavigateUri="{Binding Path=ReportAbuseUrl}"
+          Style="{StaticResource HyperlinkStyle}"
+          Command="{x:Static Tools:PackageManagerControlCommands.OpenExternalLink}">
+                    <Run
+            Text="{Binding Path=ReportAbuseUrl}" />
                 </Hyperlink>
-            </TextBlock>
+      </TextBlock>
 
-            <!-- Tags -->
-            <TextBlock
-                        Visibility="{Binding Path=Tags,Converter={StaticResource NullToVisibilityConverter}}"
-                        Grid.Row="7" Grid.Column="0" FontWeight="Bold"
-                        Margin="0,8,0,0"
-                        Text="{x:Static resx:Resources.Label_Tags}" />
-            <TextBlock
-                        Visibility="{Binding Path=Tags,Converter={StaticResource NullToVisibilityConverter}}"
-                        Text="{Binding Path=Tags}"
-                        Margin="8,8,0,0"
-                        TextWrapping="Wrap"
-                        Grid.Row="7" Grid.Column="1" />
-        </Grid>
-
-        <!-- dependencies -->
-        <StackPanel Grid.Row="3"
-                    Margin="0,8">
-            <TextBlock
-                FontWeight="Bold" Margin="0,8,0,0"
-                Text="{x:Static resx:Resources.Label_Dependencies}" />
-
-            <ItemsControl
-                ItemsSource="{Binding Path=DependencySets}"
-                Visibility="{Binding Path=HasDependencies,Converter={StaticResource BooleanToVisibilityConverter}}"
-                IsTabStop="False"
-                Margin="8,0,0,0">
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate>
-                        <StackPanel Orientation="Vertical" Margin="0,8,0,0">
-                            <TextBlock
-                                Text="{Binding TargetFramework}" FontWeight="Bold"
-                                Visibility="{Binding TargetFramework,Converter={StaticResource NullToVisibilityConverter}}" />
-                            <ItemsControl ItemsSource="{Binding Dependencies}" IsTabStop="False">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate>
-                                        <TextBlock Text="{Binding}"></TextBlock>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
-                            <TextBlock FontStyle="Italic"
-                                       Text="{x:Static resx:Resources.Text_NoDependencies}"
-                                       Visibility="{Binding Dependencies,Converter={StaticResource EmptyEnumerableToVisibilityConverter}}" />
-                        </StackPanel>
-                    </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ItemsControl>
-
-            <TextBlock
-                    Margin="0,8,0,0"
-                    Visibility="{Binding Path=HasDependencies,Converter={StaticResource InvertedBooleanToVisibilityConverter}}"
-                    FontStyle="Italic"
-                    Text="{x:Static resx:Resources.Text_NoDependencies}" />
-        </StackPanel>
+      <!-- Tags -->
+      <TextBlock
+        Visibility="{Binding Path=Tags,Converter={StaticResource NullToVisibilityConverter}}"
+        Grid.Row="7"
+        Grid.Column="0"
+        FontWeight="Bold"
+        Margin="0,8,0,0"
+        Text="{x:Static resx:Resources.Label_Tags}" />
+      <TextBlock
+        Visibility="{Binding Path=Tags,Converter={StaticResource NullToVisibilityConverter}}"
+        Text="{Binding Path=Tags}"
+        Margin="8,8,0,0"
+        TextWrapping="Wrap"
+        Grid.Row="7"
+        Grid.Column="1" />
     </Grid>
+
+    <!-- dependencies -->
+    <StackPanel
+      Grid.Row="3"
+      Margin="0,8">
+      <TextBlock
+        FontWeight="Bold"
+        Margin="0,8,0,0"
+        Text="{x:Static resx:Resources.Label_Dependencies}" />
+
+      <ItemsControl
+        ItemsSource="{Binding Path=DependencySets}"
+        Visibility="{Binding Path=HasDependencies,Converter={StaticResource BooleanToVisibilityConverter}}"
+        IsTabStop="False"
+        Margin="8,0,0,0">
+        <ItemsControl.ItemTemplate>
+          <DataTemplate>
+            <StackPanel
+              Orientation="Vertical"
+              Margin="0,8,0,0">
+              <TextBlock
+                Text="{Binding TargetFramework}"
+                FontWeight="Bold"
+                Visibility="{Binding TargetFramework,Converter={StaticResource NullToVisibilityConverter}}" />
+              <ItemsControl
+                ItemsSource="{Binding Dependencies}"
+                IsTabStop="False">
+                <ItemsControl.ItemTemplate>
+                  <DataTemplate>
+                    <TextBlock
+                      Text="{Binding}"></TextBlock>
+                  </DataTemplate>
+                </ItemsControl.ItemTemplate>
+              </ItemsControl>
+              <TextBlock
+                FontStyle="Italic"
+                Text="{x:Static resx:Resources.Text_NoDependencies}"
+                Visibility="{Binding Dependencies,Converter={StaticResource EmptyEnumerableToVisibilityConverter}}" />
+            </StackPanel>
+          </DataTemplate>
+        </ItemsControl.ItemTemplate>
+      </ItemsControl>
+
+      <TextBlock
+        Margin="0,8,0,0"
+        Visibility="{Binding Path=HasDependencies,Converter={StaticResource InvertedBooleanToVisibilityConverter}}"
+        FontStyle="Italic"
+        Text="{x:Static resx:Resources.Text_NoDependencies}" />
+    </StackPanel>
+  </Grid>
 </UserControl>

--- a/src/PackageManagement.UI/Xamls/PreviewWindow.xaml
+++ b/src/PackageManagement.UI/Xamls/PreviewWindow.xaml
@@ -1,124 +1,142 @@
 ﻿<ui:VsDialogWindow
-    x:Class="NuGet.PackageManagement.UI.PreviewWindow"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
-    xmlns:ui ="clr-namespace:NuGet.PackageManagement.UI"
-    x:Name="_self"
-    ShowInTaskbar="False"
-    WindowStyle="SingleBorderWindow"
-    WindowStartupLocation="CenterOwner"
-    Title="{Binding Title}"
-    Height="500" Width="500">
-    <Window.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="Resources.xaml" />
-            </ResourceDictionary.MergedDictionaries>
-        </ResourceDictionary>
-    </Window.Resources>
+  x:Class="NuGet.PackageManagement.UI.PreviewWindow"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
+  xmlns:ui="clr-namespace:NuGet.PackageManagement.UI"
+  x:Name="_self"
+  ShowInTaskbar="False"
+  WindowStyle="SingleBorderWindow"
+  WindowStartupLocation="CenterOwner"
+  Title="{Binding Title}"
+  Height="500"
+  Width="500">
+  <Window.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary
+          Source="Resources.xaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </Window.Resources>
 
-    <Grid Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="auto" />
-            <RowDefinition Height="auto" />
-            <RowDefinition />
-            <RowDefinition Height="auto" />
-        </Grid.RowDefinitions>
-        <TextBlock
-            Grid.Row="0"
-            Margin="12,8,12,0"
-            Text="{x:Static resx:Resources.Text_ReviewChanges}"
-            FontSize="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font122PercentSizeConverter}}" />
+  <Grid
+    Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}">
+    <Grid.RowDefinitions>
+      <RowDefinition
+        Height="auto" />
+      <RowDefinition
+        Height="auto" />
+      <RowDefinition />
+      <RowDefinition
+        Height="auto" />
+    </Grid.RowDefinitions>
+    <TextBlock
+      Grid.Row="0"
+      Margin="12,8,12,0"
+      Text="{x:Static resx:Resources.Text_ReviewChanges}"
+      FontSize="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font122PercentSizeConverter}}" />
 
-        <TextBlock
-            Grid.Row="1"
-            Margin="12,4,12,0"
-            TextWrapping="Wrap"
-            Text="{x:Static resx:Resources.Text_Changes}" />
+    <TextBlock
+      Grid.Row="1"
+      Margin="12,4,12,0"
+      TextWrapping="Wrap"
+      Text="{x:Static resx:Resources.Text_Changes}" />
 
-        <Border
-            Grid.Row="2"
-            Margin="12,12"
-            BorderBrush="{DynamicResource {x:Static resx:Brushes.BorderBrush}}"
-            BorderThickness="1">
-            <ScrollViewer
-                HorizontalScrollBarVisibility="Auto"
-                Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
-                IsTabStop="True" >
-                <ItemsControl
-                    ItemsSource="{Binding Path=PreviewResults}"
+    <Border
+      Grid.Row="2"
+      Margin="12,12"
+      BorderBrush="{DynamicResource {x:Static resx:Brushes.BorderBrush}}"
+      BorderThickness="1">
+      <ScrollViewer
+        HorizontalScrollBarVisibility="Auto"
+        Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
+        IsTabStop="True">
+        <ItemsControl
+          ItemsSource="{Binding Path=PreviewResults}"
+          IsTabStop="False">
+          <ItemsControl.ItemTemplate>
+            <DataTemplate>
+              <StackPanel
+                Margin="6, 6">
+                <TextBlock
+                  FontSize="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font122PercentSizeConverter}}"
+                  Text="{Binding Path=Name}" />
+
+                <!-- Uninstalled packages -->
+                <StackPanel
+                  Margin="0,8"
+                  Visibility="{Binding Path=Deleted,Converter={StaticResource EnumerableToVisibilityConverter}}">
+                  <TextBlock
+                    FontWeight="Bold"
+                    Text="{x:Static resx:Resources.Label_UninstalledPackages}" />
+                  <ItemsControl
+                    Margin="10,0,0,0"
+                    ItemsSource="{Binding Path=Deleted}"
                     IsTabStop="False">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <StackPanel Margin="6, 6">
-                                <TextBlock
-                                    FontSize="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font122PercentSizeConverter}}"
-                                    Text="{Binding Path=Name}" />
+                  </ItemsControl>
+                </StackPanel>
 
-                                <!-- Uninstalled packages -->
-                                <StackPanel Margin="0,8"
-                                            Visibility="{Binding Path=Deleted,Converter={StaticResource EnumerableToVisibilityConverter}}">
-                                    <TextBlock
-                        FontWeight="Bold"
-                        Text="{x:Static resx:Resources.Label_UninstalledPackages}" />
-                                    <ItemsControl
-                                        Margin="10,0,0,0"
-                                        ItemsSource="{Binding Path=Deleted}"
-                                        IsTabStop="False">
-                                    </ItemsControl>
-                                </StackPanel>
-                                
-                                <!-- Updated packages -->
-                                <StackPanel Margin="0,8"
-                                            Visibility="{Binding Path=Updated,Converter={StaticResource EnumerableToVisibilityConverter}}">
-                                    <TextBlock
-                                        FontWeight="Bold"
-                                        Text="{x:Static resx:Resources.Label_UpdatedPackages}" />
-                                    <ItemsControl
-                                        Margin="10,0,0,0"
-                                        ItemsSource="{Binding Path=Updated}"
-                                        IsTabStop="False">
-                                    </ItemsControl>
-                                </StackPanel>
+                <!-- Updated packages -->
+                <StackPanel
+                  Margin="0,8"
+                  Visibility="{Binding Path=Updated,Converter={StaticResource EnumerableToVisibilityConverter}}">
+                  <TextBlock
+                    FontWeight="Bold"
+                    Text="{x:Static resx:Resources.Label_UpdatedPackages}" />
+                  <ItemsControl
+                    Margin="10,0,0,0"
+                    ItemsSource="{Binding Path=Updated}"
+                    IsTabStop="False">
+                  </ItemsControl>
+                </StackPanel>
 
-                                <!-- Installed packages -->
-                                <StackPanel Margin="0,8"
-                                            Visibility="{Binding Path=Added,Converter={StaticResource EnumerableToVisibilityConverter}}">
-                                    <TextBlock
-                        FontWeight="Bold"
-                        Text="{x:Static resx:Resources.Label_InstalledPackages}" />
-                                    <ItemsControl
-                                        Margin="10,0,0,0"
-                                        ItemsSource="{Binding Path=Added}"
-                                        IsTabStop="False">
-                                    </ItemsControl>
-                                </StackPanel>
-                            </StackPanel>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </ScrollViewer>
-        </Border>
+                <!-- Installed packages -->
+                <StackPanel
+                  Margin="0,8"
+                  Visibility="{Binding Path=Added,Converter={StaticResource EnumerableToVisibilityConverter}}">
+                  <TextBlock
+                    FontWeight="Bold"
+                    Text="{x:Static resx:Resources.Label_InstalledPackages}" />
+                  <ItemsControl
+                    Margin="10,0,0,0"
+                    ItemsSource="{Binding Path=Added}"
+                    IsTabStop="False">
+                  </ItemsControl>
+                </StackPanel>
+              </StackPanel>
+            </DataTemplate>
+          </ItemsControl.ItemTemplate>
+        </ItemsControl>
+      </ScrollViewer>
+    </Border>
 
-        <Grid Grid.Row="3" Background="{Binding ElementName=_self, Path=Background}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition />
-                <ColumnDefinition Width="auto" />
-                <ColumnDefinition Width="auto" />
-            </Grid.ColumnDefinitions>
-            <Button Grid.Column="1"
-                    MinWidth="86"
-                    MinHeight="24"
-                    Margin="0,12"
-                    AutomationProperties.AutomationId="OK"
-                    Content="{x:Static resx:Resources.Button_OK}" Click="OkButtonClicked" />
-            <Button Grid.Column="2"
-                    MinWidth="86"
-                    MinHeight="24"
-                    Margin="6,12,12,12"
-                    AutomationProperties.AutomationId="Cancel"
-                    Content="{x:Static resx:Resources.Button_Cancel}" Click="CancelButtonClicked" />
-        </Grid>
+    <Grid
+      Grid.Row="3"
+      Background="{Binding ElementName=_self, Path=Background}">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition />
+        <ColumnDefinition
+          Width="auto" />
+        <ColumnDefinition
+          Width="auto" />
+      </Grid.ColumnDefinitions>
+      <Button
+        Grid.Column="1"
+        MinWidth="86"
+        MinHeight="24"
+        Margin="0,12"
+        AutomationProperties.AutomationId="OK"
+        Content="{x:Static resx:Resources.Button_OK}"
+        Click="OkButtonClicked" />
+      <Button
+        Grid.Column="2"
+        MinWidth="86"
+        MinHeight="24"
+        Margin="6,12,12,12"
+        AutomationProperties.AutomationId="Cancel"
+        Content="{x:Static resx:Resources.Button_Cancel}"
+        Click="CancelButtonClicked" />
     </Grid>
+  </Grid>
 </ui:VsDialogWindow>

--- a/src/PackageManagement.UI/Xamls/ProjectList.xaml
+++ b/src/PackageManagement.UI/Xamls/ProjectList.xaml
@@ -1,76 +1,87 @@
-﻿<UserControl x:Class="NuGet.PackageManagement.UI.ProjectList"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"             
-             mc:Ignorable="d"
-             d:DesignHeight="300" d:DesignWidth="300">
-    <UserControl.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="Resources.xaml" />
-            </ResourceDictionary.MergedDictionaries>
-        </ResourceDictionary>
-    </UserControl.Resources>
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="8" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="8" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-        <TextBlock
-            Grid.Row="0"
-            Text="{x:Static resx:Resources.Label_Projects}" />
+﻿<UserControl
+  x:Class="NuGet.PackageManagement.UI.ProjectList"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  mc:Ignorable="d"
+  d:DesignHeight="300"
+  d:DesignWidth="300">
+  <UserControl.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary
+          Source="Resources.xaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </UserControl.Resources>
+  <Grid>
+    <Grid.RowDefinitions>
+      <RowDefinition
+        Height="Auto" />
+      <RowDefinition
+        Height="8" />
+      <RowDefinition
+        Height="Auto" />
+      <RowDefinition
+        Height="8" />
+      <RowDefinition
+        Height="*" />
+    </Grid.RowDefinitions>
+    <TextBlock
+      Grid.Row="0"
+      Text="{x:Static resx:Resources.Label_Projects}" />
 
-        <Grid Grid.Row="2">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition />
-                <ColumnDefinition />
-            </Grid.ColumnDefinitions>
-            <CheckBox Grid.Column="0"
-                      x:Name="_checkBox"
-                      Margin="6,0,0,0"
-                      Foreground="{DynamicResource {x:Static resx:Brushes.UIText}}"
-                      IsChecked="{Binding CheckboxState}"
-                      IsThreeState="False"
-                      Checked="CheckBox_Checked"
-                      Unchecked="_checkBox_Unchecked"
-                      Content="{Binding SelectCheckboxText}" />
-            <CheckBox Grid.Column="1"
-                      Margin="0,0,6,0"
-                      HorizontalAlignment="Right"
-                      Foreground="{DynamicResource {x:Static resx:Brushes.UIText}}"
-                      IsChecked="{Binding ShowAll}"
-                      Content="{x:Static resx:Resources.Text_ShowAll}" />
-        </Grid>
-        <Border
-            Grid.Row="4"
-            BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
-            BorderThickness="1">
-            <ScrollViewer
-                HorizontalScrollBarVisibility="Auto"
-                Background="{DynamicResource {x:Static resx:Brushes.DetailPaneBackground}}"
-                IsTabStop="True">
-                <ItemsControl
-            x:Name="_projectList"
-            ItemsSource="{Binding Path=Projects}"
-            IsTabStop="False">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <CheckBox
-                                Content="{Binding Path=DisplayText}"
-                                Foreground="{DynamicResource {x:Static resx:Brushes.UIText}}"
-                                Margin="6,4,0,2"
-                                VerticalContentAlignment="Center"
-                                IsChecked="{Binding Path=Selected}"
-                                IsEnabled="{Binding Path=Enabled}" />
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </ScrollViewer>
-        </Border>
+    <Grid
+      Grid.Row="2">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition />
+        <ColumnDefinition />
+      </Grid.ColumnDefinitions>
+      <CheckBox
+        Grid.Column="0"
+        x:Name="_checkBox"
+        Margin="6,0,0,0"
+        Foreground="{DynamicResource {x:Static resx:Brushes.UIText}}"
+        IsChecked="{Binding CheckboxState}"
+        IsThreeState="False"
+        Checked="CheckBox_Checked"
+        Unchecked="_checkBox_Unchecked"
+        Content="{Binding SelectCheckboxText}" />
+      <CheckBox
+        Grid.Column="1"
+        Margin="0,0,6,0"
+        HorizontalAlignment="Right"
+        Foreground="{DynamicResource {x:Static resx:Brushes.UIText}}"
+        IsChecked="{Binding ShowAll}"
+        Content="{x:Static resx:Resources.Text_ShowAll}" />
     </Grid>
+    <Border
+      Grid.Row="4"
+      BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+      BorderThickness="1">
+      <ScrollViewer
+        HorizontalScrollBarVisibility="Auto"
+        Background="{DynamicResource {x:Static resx:Brushes.DetailPaneBackground}}"
+        IsTabStop="True">
+        <ItemsControl
+          x:Name="_projectList"
+          ItemsSource="{Binding Path=Projects}"
+          IsTabStop="False">
+          <ItemsControl.ItemTemplate>
+            <DataTemplate>
+              <CheckBox
+                Content="{Binding Path=DisplayText}"
+                Foreground="{DynamicResource {x:Static resx:Brushes.UIText}}"
+                Margin="6,4,0,2"
+                VerticalContentAlignment="Center"
+                IsChecked="{Binding Path=Selected}"
+                IsEnabled="{Binding Path=Enabled}" />
+            </DataTemplate>
+          </ItemsControl.ItemTemplate>
+        </ItemsControl>
+      </ScrollViewer>
+    </Border>
+  </Grid>
 </UserControl>

--- a/src/PackageManagement.UI/Xamls/Resources.xaml
+++ b/src/PackageManagement.UI/Xamls/Resources.xaml
@@ -1,71 +1,133 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:Tools="clr-namespace:NuGet.PackageManagement.UI"
-                    xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Tools:StyleKeyConverter x:Key="StyleKeyConverter" />
-    <BitmapImage x:Key="BitmapImage_DefaultIcon" UriSource="../Resources/packageicon.png" />
+﻿<ResourceDictionary
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:Tools="clr-namespace:NuGet.PackageManagement.UI"
+  xmlns:resx="clr-namespace:NuGet.PackageManagement.UI"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <Tools:StyleKeyConverter
+    x:Key="StyleKeyConverter" />
+  <BitmapImage
+    x:Key="BitmapImage_DefaultIcon"
+    UriSource="../Resources/packageicon.png" />
 
-    <Tools:PackageStatusToInstallImageVisibilityConverter x:Key="PackageStatusToInstallImageVis" />
-    <Tools:PackageStatusToUpdateImageVisibilityConverter x:Key="PackageStatusToUpdateImageConverter" />
-    <Tools:IconUrlToVisibilityConverter x:Key="IconUrlToVisibilityConverter" />
+  <Tools:PackageStatusToInstallImageVisibilityConverter
+    x:Key="PackageStatusToInstallImageVis" />
+  <Tools:PackageStatusToUpdateImageVisibilityConverter
+    x:Key="PackageStatusToUpdateImageConverter" />
+  <Tools:IconUrlToVisibilityConverter
+    x:Key="IconUrlToVisibilityConverter" />
 
-    <Tools:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
-    <Tools:EnumerableToVisibilityConverter Inverted="true" x:Key="EmptyEnumerableToVisibilityConverter" />
-    <Tools:EnumerableToVisibilityConverter x:Key="EnumerableToVisibilityConverter" />
-    <Tools:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-    <Tools:BooleanToVisibilityConverter Inverted="True" x:Key="InvertedBooleanToVisibilityConverter" />
-    <Tools:DownloadCountToVisibilityConverter x:Key="DownloadCountToVisibilityConverter" />
-    <Tools:FontSizeConverter Scale="122" x:Key="Font122PercentSizeConverter" />
-    <Tools:FontSizeConverter Scale="155" x:Key="Font155PercentSizeConverter" />
+  <Tools:NullToVisibilityConverter
+    x:Key="NullToVisibilityConverter" />
+  <Tools:EnumerableToVisibilityConverter
+    Inverted="true"
+    x:Key="EmptyEnumerableToVisibilityConverter" />
+  <Tools:EnumerableToVisibilityConverter
+    x:Key="EnumerableToVisibilityConverter" />
+  <Tools:BooleanToVisibilityConverter
+    x:Key="BooleanToVisibilityConverter" />
+  <Tools:BooleanToVisibilityConverter
+    Inverted="True"
+    x:Key="InvertedBooleanToVisibilityConverter" />
+  <Tools:DownloadCountToVisibilityConverter
+    x:Key="DownloadCountToVisibilityConverter" />
+  <Tools:FontSizeConverter
+    Scale="122"
+    x:Key="Font122PercentSizeConverter" />
+  <Tools:FontSizeConverter
+    Scale="155"
+    x:Key="Font155PercentSizeConverter" />
 
-    <DataTemplate DataType="{x:Type Tools:PackageDependencyMetadata}">
-        <TextBlock Text="{Binding}" />
-    </DataTemplate>
+  <DataTemplate
+    DataType="{x:Type Tools:PackageDependencyMetadata}">
+    <TextBlock
+      Text="{Binding}" />
+  </DataTemplate>
 
-    <DataTemplate DataType="{x:Type Tools:SearchResultPackageMetadata}">
-        <Tools:PackageItemControl DataContext="{Binding}" />
-    </DataTemplate>
+  <DataTemplate
+    DataType="{x:Type Tools:SearchResultPackageMetadata}">
+    <Tools:PackageItemControl
+      DataContext="{Binding}" />
+  </DataTemplate>
 
-    <Style x:Key="TooltipStyle" TargetType="{x:Type TextBlock}">
-        <Setter Property="TextWrapping" Value="Wrap" />
-        <Setter Property="MaxWidth" Value="300" />
-    </Style>
-    
-    <Style TargetType="{x:Type Hyperlink}" x:Key="HyperlinkStyle">
-        <Setter Property="Foreground" Value="{DynamicResource {x:Static resx:Brushes.ControlLinkTextKey}}" />
+  <Style
+    x:Key="TooltipStyle"
+    TargetType="{x:Type TextBlock}">
+    <Setter
+      Property="TextWrapping"
+      Value="Wrap" />
+    <Setter
+      Property="MaxWidth"
+      Value="300" />
+  </Style>
 
-        <Style.Triggers>
-            <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="Foreground" Value="{DynamicResource {x:Static resx:Brushes.ControlLinkTextHoverKey}}" />
-            </Trigger>
+  <Style
+    TargetType="{x:Type Hyperlink}"
+    x:Key="HyperlinkStyle">
+    <Setter
+      Property="Foreground"
+      Value="{DynamicResource {x:Static resx:Brushes.ControlLinkTextKey}}" />
 
-            <Trigger Property="IsMouseOver" Value="False">
-                <Setter Property="TextBlock.TextDecorations" Value="{x:Null}" />
-            </Trigger>
+    <Style.Triggers>
+      <Trigger
+        Property="IsMouseOver"
+        Value="True">
+        <Setter
+          Property="Foreground"
+          Value="{DynamicResource {x:Static resx:Brushes.ControlLinkTextHoverKey}}" />
+      </Trigger>
 
-            <Trigger Property="NavigateUri" Value="{x:Null}">
-                <Setter Property="Foreground" Value="{DynamicResource {x:Static resx:Brushes.WindowTextKey}}" />
-                <Setter Property="TextBlock.TextDecorations" Value="{x:Null}" />
-                <Setter Property="IsEnabled" Value="False" />
-            </Trigger>
-        </Style.Triggers>
-    </Style>
+      <Trigger
+        Property="IsMouseOver"
+        Value="False">
+        <Setter
+          Property="TextBlock.TextDecorations"
+          Value="{x:Null}" />
+      </Trigger>
 
-    <Style x:Key="PackageIconImageStyle" TargetType="{x:Type Image}">
-        <Setter Property="HorizontalAlignment" Value="Center" />
-        <Setter Property="StretchDirection" Value="DownOnly" />
-        <Setter Property="Stretch" Value="Fill" />
-        <Style.Triggers>
-            <EventTrigger RoutedEvent="ImageFailed">
-                <BeginStoryboard>
-                    <Storyboard>
-                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Source" FillBehavior="HoldEnd">
-                            <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{StaticResource BitmapImage_DefaultIcon}">
-                            </DiscreteObjectKeyFrame>
-                        </ObjectAnimationUsingKeyFrames>
-                    </Storyboard>
-                </BeginStoryboard>
-            </EventTrigger>
-        </Style.Triggers>
-    </Style>
+      <Trigger
+        Property="NavigateUri"
+        Value="{x:Null}">
+        <Setter
+          Property="Foreground"
+          Value="{DynamicResource {x:Static resx:Brushes.WindowTextKey}}" />
+        <Setter
+          Property="TextBlock.TextDecorations"
+          Value="{x:Null}" />
+        <Setter
+          Property="IsEnabled"
+          Value="False" />
+      </Trigger>
+    </Style.Triggers>
+  </Style>
+
+  <Style
+    x:Key="PackageIconImageStyle"
+    TargetType="{x:Type Image}">
+    <Setter
+      Property="HorizontalAlignment"
+      Value="Center" />
+    <Setter
+      Property="StretchDirection"
+      Value="DownOnly" />
+    <Setter
+      Property="Stretch"
+      Value="Fill" />
+    <Style.Triggers>
+      <EventTrigger
+        RoutedEvent="ImageFailed">
+        <BeginStoryboard>
+          <Storyboard>
+            <ObjectAnimationUsingKeyFrames
+              Storyboard.TargetProperty="Source"
+              FillBehavior="HoldEnd">
+              <DiscreteObjectKeyFrame
+                KeyTime="0:0:0"
+                Value="{StaticResource BitmapImage_DefaultIcon}">
+              </DiscreteObjectKeyFrame>
+            </ObjectAnimationUsingKeyFrames>
+          </Storyboard>
+        </BeginStoryboard>
+      </EventTrigger>
+    </Style.Triggers>
+  </Style>
 </ResourceDictionary>

--- a/src/PackageManagement.UI/Xamls/UpdateAvailableIndicator.xaml
+++ b/src/PackageManagement.UI/Xamls/UpdateAvailableIndicator.xaml
@@ -1,27 +1,36 @@
-﻿<UserControl x:Class="NuGet.PackageManagement.UI.UpdateAvailableIndicator"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             mc:Ignorable="d"
-             d:DesignHeight="300" d:DesignWidth="300">
+﻿<UserControl
+  x:Class="NuGet.PackageManagement.UI.UpdateAvailableIndicator"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  mc:Ignorable="d"
+  d:DesignHeight="300"
+  d:DesignWidth="300">
 
-    <Rectangle>
-        <Rectangle.LayoutTransform>
-            <RotateTransform Angle="90" />
-        </Rectangle.LayoutTransform>
-        <Rectangle.Fill>
-            <DrawingBrush>
-                <DrawingBrush.Drawing>
-                    <DrawingGroup>
-                        <DrawingGroup.Children>
-                            <GeometryDrawing Brush="#FFF6F6F6" Geometry="F1M15,8C15,11.866 11.866,15 8,15 4.134,15 1,11.866 1,8 1,4.134 4.134,1 8,1 11.866,1 15,4.134 15,8" />
-                            <GeometryDrawing Brush="#FF1AA1E2" Geometry="F1M9,11L7,11 9,9 4,9 4,7 9,7 7,5 9,5 12,8z M8,2C4.755,2 2,4.756 2,8 2,11.247 4.755,14 8,14 11.245,14 14,11.247 14,8 14,4.756 11.245,2 8,2" />
-                            <GeometryDrawing Brush="#FFF0EFF1" Geometry="F1M9,11L7,11 9,9 4,9 4,7 9,7 7,5 9,5 12,8z" />
-                        </DrawingGroup.Children>
-                    </DrawingGroup>
-                </DrawingBrush.Drawing>
-            </DrawingBrush>
-        </Rectangle.Fill>
-    </Rectangle>
+  <Rectangle>
+    <Rectangle.LayoutTransform>
+      <RotateTransform
+        Angle="-90" />
+    </Rectangle.LayoutTransform>
+    <Rectangle.Fill>
+      <DrawingBrush>
+        <DrawingBrush.Drawing>
+          <DrawingGroup>
+            <DrawingGroup.Children>
+              <GeometryDrawing
+                Brush="#FFF6F6F6"
+                Geometry="F1M15,8C15,11.866 11.866,15 8,15 4.134,15 1,11.866 1,8 1,4.134 4.134,1 8,1 11.866,1 15,4.134 15,8" />
+              <GeometryDrawing
+                Brush="#FF1AA1E2"
+                Geometry="F1M9,11L7,11 9,9 4,9 4,7 9,7 7,5 9,5 12,8z M8,2C4.755,2 2,4.756 2,8 2,11.247 4.755,14 8,14 11.245,14 14,11.247 14,8 14,4.756 11.245,2 8,2" />
+              <GeometryDrawing
+                Brush="#FFF0EFF1"
+                Geometry="F1M9,11L7,11 9,9 4,9 4,7 9,7 7,5 9,5 12,8z" />
+            </DrawingGroup.Children>
+          </DrawingGroup>
+        </DrawingBrush.Drawing>
+      </DrawingBrush>
+    </Rectangle.Fill>
+  </Rectangle>
 </UserControl>

--- a/test/PackageManagement.Cmdlets.Test/PowerShellCmdletsTest.cs
+++ b/test/PackageManagement.Cmdlets.Test/PowerShellCmdletsTest.cs
@@ -1,10 +1,8 @@
-﻿using NuGet.Configuration;
-using NuGet.PackageManagement;
-using System;
+﻿using System;
 using System.Management.Automation;
-using System.Management.Automation.Runspaces;
-using Xunit;
+using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
+using Xunit;
 
 namespace PackageManagement.Cmdlets.Test
 {


### PR DESCRIPTION
Formatting changes to XAML files and packagemanagement to match new formatting rules (and minimize diffs in the future).

New rules - 
Tab spacing = 2
Place property on new line = Always